### PR TITLE
feat: update useWalletTransactionSignAndSend to support multiple instructions

### DIFF
--- a/templates/template-next-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-next-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -5,14 +5,14 @@ import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithS
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
-  return async (ix: Instruction, signer: TransactionSendingSigner) => {
+  return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
 
     const transaction = createTransaction({
       feePayer: signer,
       version: 0,
       latestBlockhash,
-      instructions: [ix],
+      instructions: Array.isArray(ix) ? ix : [ix],
     })
 
     const signature = await signAndSendTransactionMessageWithSigners(transaction)

--- a/templates/template-next-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-next-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -5,14 +5,14 @@ import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithS
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
-  return async (ix: Instruction, signer: TransactionSendingSigner) => {
+  return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
 
     const transaction = createTransaction({
       feePayer: signer,
       version: 0,
       latestBlockhash,
-      instructions: [ix],
+      instructions: Array.isArray(ix) ? ix : [ix],
     })
 
     const signature = await signAndSendTransactionMessageWithSigners(transaction)

--- a/templates/template-next-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-next-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -5,14 +5,14 @@ import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithS
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
-  return async (ix: Instruction, signer: TransactionSendingSigner) => {
+  return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
 
     const transaction = createTransaction({
       feePayer: signer,
       version: 0,
       latestBlockhash,
-      instructions: [ix],
+      instructions: Array.isArray(ix) ? ix : [ix],
     })
 
     const signature = await signAndSendTransactionMessageWithSigners(transaction)

--- a/templates/template-react-vite-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-react-vite-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -5,14 +5,14 @@ import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithS
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
-  return async (ix: Instruction, signer: TransactionSendingSigner) => {
+  return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
 
     const transaction = createTransaction({
       feePayer: signer,
       version: 0,
       latestBlockhash,
-      instructions: [ix],
+      instructions: Array.isArray(ix) ? ix : [ix],
     })
 
     const signature = await signAndSendTransactionMessageWithSigners(transaction)

--- a/templates/template-react-vite-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-react-vite-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -5,14 +5,14 @@ import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithS
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
-  return async (ix: Instruction, signer: TransactionSendingSigner) => {
+  return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
 
     const transaction = createTransaction({
       feePayer: signer,
       version: 0,
       latestBlockhash,
-      instructions: [ix],
+      instructions: Array.isArray(ix) ? ix : [ix],
     })
 
     const signature = await signAndSendTransactionMessageWithSigners(transaction)

--- a/templates/template-react-vite-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/templates/template-react-vite-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -5,14 +5,14 @@ import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithS
 export function useWalletTransactionSignAndSend() {
   const { client } = useWalletUi()
 
-  return async (ix: Instruction, signer: TransactionSendingSigner) => {
+  return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()
 
     const transaction = createTransaction({
       feePayer: signer,
       version: 0,
       latestBlockhash,
-      instructions: [ix],
+      instructions: Array.isArray(ix) ? ix : [ix],
     })
 
     const signature = await signAndSendTransactionMessageWithSigners(transaction)


### PR DESCRIPTION
The function returned by `useWalletTransactionSignAndSend` now accepts a single `Instruction` or an array of `Instruction`.

```ts
await signAndSend(getSomeInstruction({ payer }), payer)
await signAndSend([getSomeInstruction({ payer }), ...otherIxs], payer)
```

Fixes #75 