### PR TITLE
docs: add CONTRIBUTING.md and MAINTAINERS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing to create-solana-dapp
+
+We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+## We Develop with GitHub
+
+We use GitHub to host code, to track issues and feature requests, as well as accept pull requests.
+
+## We use [GitHub Flow](https://guides.github.com/introduction/flow/index.html), so all code changes happen through pull requests
+
+Pull requests are the best way to propose changes to the codebase. We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `main`.
+2. Prefix your branch with your GitHub username (eg, `beeman/fix-anchor-issue` and not `fix/anchor-issue`)
+3. If you've added code that should be tested, add tests.
+4. If you've changed APIs, update the documentation.
+5. Ensure the test suite passes.
+6. Make sure your code lints.
+7. Issue that pull request!
+
+## Any contributions you make will be under the MIT Software License
+
+In short, when you submit code changes, your submissions are understood to be under the same
+[MIT License](https://choosealicense.com/licenses/mit/) that covers the project.
+
+## Report bugs using GitHub's [issues](https://github.com/solana-foundation/templates/issues)
+
+We use GitHub issues to track public bugs. Report a bug by
+[opening a new issue](https://github.com/solana-foundation/templates/issues/new); it's that easy!
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can.
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+People _love_ thorough bug reports.
+
+## Use a Consistent Coding Style
+
+- Code is formatted using the prettier configuration in the project root.
+- Run `pnpm format` to make sure your code is formatted correctly.
+
+## Development Workflow
+
+In this section, you'll find the basic commands you need to run for building, testing, and maintaining the quality of
+the codebase.
+
+### Building the Project
+
+To compile the project and generate the necessary artifacts, use the build command:
+
+```shell
+pnpm build
+```
+
+You can build the project in watch mode by using the following command for faster feedback:
+
+```shell
+pnpm build:watch
+```
+
+### Running Tests
+
+To ensure your contributions do not break any existing functionality, run the test suite with the following command:
+
+```shell
+pnpm test
+```
+
+You can run the tests in watch mode by running the following command for faster feedback:
+
+```shell
+pnpm dev
+```
+
+### Linting Your Code
+
+It's important to maintain the coding standards of the project. Lint your code by executing:
+
+```shell
+pnpm lint
+```
+
+### Committing Your Changes
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for commit:
+
+- `fix`: a commit of the type fix patches a bug in your codebase (this correlates with PATCH in semantic versioning).
+- `feat`: a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in semantic
+  versioning).
+- `BREAKING CHANGE`: a commit that has the text BREAKING CHANGE: at the beginning of its optional body or footer section
+  introduces a breaking API change (correlating with MAJOR in semantic versioning). A BREAKING CHANGE can be part of
+  commits of any type.
+- Others: commit types other than fix: and feat: are allowed, for example @commitlint/config-conventional (based on the
+  Angular convention) recommends build:, chore:, ci:, docs:, style:, refactor:, perf:, test:, and others.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under its MIT License.
+
+## References
+
+This document was adapted from the open-source contribution guidelines for
+[Facebook's Draft](https://github.com/facebook/draft-js/blob/master/CONTRIBUTING.md)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,82 @@
+# Template Maintainers
+
+This document is aimed at developers that maintain templates in this repository.
+
+The templates for [create-solana-dapp](https://github.com/solana-developers/create-solana-dapp) (eg, "the cli") are
+currently all
+based on JavaScript/TypeScript.
+
+This means that they expect to be installed by running a Node package manager install command.
+
+The cli supports creating templates with `bun`/`npm`/`pnpm`/`yarn`, in this repo though the default package manager is
+`pnpm`.
+
+We depend on tests to ensure that templates will work well across the different package managers.
+
+## Template groups
+
+The repository is divided in groups:
+
+```shell
+# Community templates
+community
+# Legacy templates (eg web3js)
+legacy
+# Modern templates (eg gill/@solana/kit)
+templates
+# Mobile templates
+mobile
+```
+
+These groups are configured in the `repokit.groups` array in `package.json`.
+
+The [CODEOWNERS](./CODEOWNERS) file is used by GitHub to assign owners for review on Pull Requests.
+
+## Template naming
+
+> Naming is one of the two hard things in computer science. Next to invalidating cache and off-by-one errors.
+
+We aim to keep the following structure:
+
+```shell
+[group]/[sdk]-[name]-[variant]
+```
+
+- Group
+  - One of `community`/`legacy`/`templates`/`mobile` as per `repokit.groups` in `package.json`.
+- SDK
+  - This specifies which primary SDK is used. One of `gill` or `web3js`.
+- Name
+  - This is the name of the template. Either the framework (`next`/`expo`/`react-vite`) or the name of your
+    organization (`jito`/`metaplex`/ etc).
+- Variant
+  - The variant of your template. Something that makes it clear what this is about.
+
+Take a look at the `legacy`, `templates` or `mobile` templates for inspiration.
+
+Examples are:
+
+```shell
+# Template by Jito for doing airdrops
+community/gill-jito-airdrops
+# Template by Metaplex for MPL Core Collections
+community/web3js-metaplex-core
+# Template by Metaplex for MPL Core Collections with MPL 404 (variant of the above)
+community/web3js-metaplex-core-404
+```
+
+If in doubt, please reach out to the repo maintainer and discuss it!
+
+## Adding a new template
+
+- Decide on the group. Pick `community` unless instructed otherwise.
+- Decide on the repository `group` and `name`. Make sure it follows the convention.
+- Create the new directory and add your code.
+- Run `pnpm repokit lint` to make sure the template metadata is valid.
+- TBD: any more steps...
+
+## Repokit
+
+Repokit is a tool to automate management of template repos to maintain consitency.
+
+TBD: More docs!


### PR DESCRIPTION
This PR introduces two new documentation files to improve project clarity and maintainability:
 - **CONTRIBUTING.md**: Provides comprehensive guidelines for external contributors, covering how to report bugs, the pull request workflow (GitHub Flow), coding style
     conventions, development commands (build, test, lint), and commit message standards (Conventional Commits). This aims to streamline the contribution process and ensure
     consistency.
 - **MAINTAINERS.md**: Offers essential information for template maintainers, detailing the project's template grouping structure, naming conventions for new templates,
     and initial steps for adding new templates. It also briefly introduces `repokit` as a tool for template management.
