### PR TITLE
chore: remove legacy templates category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,25 +2,14 @@
 node_modules
 
 # We only want a top-level `pnpm-lock.yaml` file.
-legacy/**/package-lock.json
-legacy/**/pnpm-lock.yaml
-legacy/**/yarn.lock
 templates/**/package-lock.json
 templates/**/pnpm-lock.yaml
 templates/**/yarn.lock
+web3js/**/package-lock.json
+web3js/**/pnpm-lock.yaml
+web3js/**/yarn.lock
 
 # Ignore any dist, tmp, or node_modules directories
-legacy/**/.next
-legacy/**/.env
-legacy/**/anchor/target/debug
-legacy/**/anchor/target/deploy
-legacy/**/anchor/target/release
-legacy/**/anchor/target/sbf-solana-solana
-legacy/**/anchor/target/test-ledger
-legacy/**/anchor/target/.rustc_info.json
-legacy/**/dist
-legacy/**/node_modules
-legacy/**/tmp
 templates/**/.next
 templates/**/.env
 templates/**/anchor/target/debug
@@ -32,3 +21,14 @@ templates/**/anchor/target/.rustc_info.json
 templates/**/dist
 templates/**/node_modules
 templates/**/tmp
+web3js/**/.next
+web3js/**/.env
+web3js/**/anchor/target/debug
+web3js/**/anchor/target/deploy
+web3js/**/anchor/target/release
+web3js/**/anchor/target/sbf-solana-solana
+web3js/**/anchor/target/test-ledger
+web3js/**/anchor/target/.rustc_info.json
+web3js/**/dist
+web3js/**/node_modules
+web3js/**/tmp

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,17 +6,6 @@ pnpm-lock.yaml
 .next
 
 # Ignore any dist, tmp, or node_modules directories
-legacy/**/.env
-legacy/**/.anchor
-legacy/**/anchor/target/debug
-legacy/**/anchor/target/deploy
-legacy/**/anchor/target/release
-legacy/**/anchor/target/sbf-solana-solana
-legacy/**/anchor/target/test-ledger
-legacy/**/anchor/target/.rustc_info.json
-legacy/**/dist
-legacy/**/node_modules
-legacy/**/tmp
 templates/**/.env
 templates/**/.anchor
 templates/**/anchor/src/client/js/generated
@@ -29,3 +18,14 @@ templates/**/anchor/target/.rustc_info.json
 templates/**/dist
 templates/**/node_modules
 templates/**/tmp
+web3js/**/.env
+web3js/**/.anchor
+web3js/**/anchor/target/debug
+web3js/**/anchor/target/deploy
+web3js/**/anchor/target/release
+web3js/**/anchor/target/sbf-solana-solana
+web3js/**/anchor/target/test-ledger
+web3js/**/anchor/target/.rustc_info.json
+web3js/**/dist
+web3js/**/node_modules
+web3js/**/tmp

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 * @beeman
-/legacy @beeman
 /mobile @beeman
 /templates @beeman
+/web3js @beeman

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,12 +20,12 @@ The repository is divided in groups:
 ```shell
 # Community templates
 community
-# Legacy templates (eg web3js)
-legacy
 # Modern templates (eg gill/@solana/kit)
 templates
 # Mobile templates
 mobile
+# Solana Web3.js templates (legacy)
+web3js
 ```
 
 These groups are configured in the `repokit.groups` array in `package.json`.
@@ -43,7 +43,7 @@ We aim to keep the following structure:
 ```
 
 - Group
-  - One of `community`/`legacy`/`templates`/`mobile` as per `repokit.groups` in `package.json`.
+  - One of `community`/`templates`/`mobile`/`web3js` as per `repokit.groups` in `package.json`.
 - SDK
   - This specifies which primary SDK is used. One of `gill` or `web3js`.
 - Name
@@ -52,7 +52,7 @@ We aim to keep the following structure:
 - Variant
   - The variant of your template. Something that makes it clear what this is about.
 
-Take a look at the `legacy`, `templates` or `mobile` templates for inspiration.
+Take a look at the `templates`, `web3js`, or `mobile` templates for inspiration.
 
 Examples are:
 

--- a/README.md
+++ b/README.md
@@ -153,17 +153,13 @@ Templates using @solana/web3.js (legacy)
 
 `anchor-basic` `react` `solana-web3js` `tailwind` `typescript` `vite` `wallet-adapter`
 
-### [legacy-react-vite-tailwind-counter](web3js/legacy-react-vite-tailwind-counter)
+### [web3js-react-vite-tailwind-counter](web3js/web3js-react-vite-tailwind-counter)
 
 `gh:solana-foundation/templates/web3js/web3js-react-vite-tailwind-counter`
 
 > React + Vite, Tailwind, @solana/web3.js, Wallet Adapter, Anchor Counter program
 
-`anchor-counter` `legacy` `react` `solana-web3js` `tailwind` `typescript` `vite` `wallet-adapter`
-
-# Legacy Templates
-
-Legacy templates using @solana/web3.js
+`anchor-counter` `web3js` `react` `solana-web3js` `tailwind` `typescript` `vite` `wallet-adapter`
 
 # Community Templates
 

--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -130,17 +130,13 @@ Templates using @solana/web3.js (legacy)
 
 `anchor-basic` `react` `solana-web3js` `tailwind` `typescript` `vite` `wallet-adapter`
 
-### [legacy-react-vite-tailwind-counter](web3js/legacy-react-vite-tailwind-counter)
+### [web3js-react-vite-tailwind-counter](web3js/web3js-react-vite-tailwind-counter)
 
 `gh:solana-foundation/templates/web3js/web3js-react-vite-tailwind-counter`
 
 > React + Vite, Tailwind, @solana/web3.js, Wallet Adapter, Anchor Counter program
 
-`anchor-counter` `legacy` `react` `solana-web3js` `tailwind` `typescript` `vite` `wallet-adapter`
-
-# Legacy Templates
-
-Legacy templates using @solana/web3.js
+`anchor-counter` `web3js` `react` `solana-web3js` `tailwind` `typescript` `vite` `wallet-adapter`
 
 # Community Templates
 

--- a/package.json
+++ b/package.json
@@ -38,11 +38,6 @@
         "path": "web3js"
       },
       {
-        "description": "Legacy templates using @solana/web3.js",
-        "name": "Legacy Templates",
-        "path": "legacy"
-      },
-      {
         "description": "Templates maintained by the Solana community",
         "name": "Community Templates",
         "path": "community"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,5 @@
 packages:
   - community/*
-  - legacy/*
   - mobile/*
   - templates/*
   - web3js/*

--- a/templates.json
+++ b/templates.json
@@ -128,7 +128,7 @@
         "id": "gh:solana-foundation/templates/web3js/web3js-react-vite-tailwind-counter",
         "keywords": [
           "anchor-counter",
-          "legacy",
+          "web3js",
           "react",
           "solana-web3js",
           "tailwind",
@@ -136,16 +136,10 @@
           "vite",
           "wallet-adapter"
         ],
-        "name": "legacy-react-vite-tailwind-counter",
+        "name": "web3js-react-vite-tailwind-counter",
         "path": "web3js/web3js-react-vite-tailwind-counter"
       }
     ]
-  },
-  {
-    "description": "Legacy templates using @solana/web3.js",
-    "name": "Legacy Templates",
-    "path": "legacy",
-    "templates": []
   },
   {
     "description": "Templates maintained by the Solana community",

--- a/web3js/web3js-react-vite-tailwind-counter/README.md
+++ b/web3js/web3js-react-vite-tailwind-counter/README.md
@@ -1,4 +1,4 @@
-# legacy-react-vite-tailwind-counter
+# web3js-react-vite-tailwind-counter
 
 This is a Vite app containing:
 
@@ -14,7 +14,7 @@ This is a Vite app containing:
 #### Download the template
 
 ```shell
-pnpm create solana-dapp@latest -t gh:solana-foundation/templates/legacy/legacy-react-vite-tailwind-counter
+pnpm create solana-dapp@latest -t gh:solana-foundation/templates/web3js/web3js-react-vite-tailwind-counter
 ```
 
 #### Install Dependencies

--- a/web3js/web3js-react-vite-tailwind-counter/package.json
+++ b/web3js/web3js-react-vite-tailwind-counter/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "legacy-react-vite-tailwind-counter",
+  "name": "web3js-react-vite-tailwind-counter",
   "description": "React + Vite, Tailwind, @solana/web3.js, Wallet Adapter, Anchor Counter program",
   "keywords": [
     "anchor-counter",
-    "legacy",
+    "web3js",
     "react",
     "solana-web3js",
     "tailwind",


### PR DESCRIPTION
Last clean  up of references to the `legacy` template group after renaming `legacy-*` to `web3js-*` in #101 / #102 