### PR TITLE
fix: add back @solana/kit to gill-jito-airdrop template

### DIFF
--- a/community/gill-jito-airdrop/package.json
+++ b/community/gill-jito-airdrop/package.json
@@ -40,6 +40,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "@solana/kit": "^2.3.0",
     "@tanstack/react-query": "^5.82.0",
     "@wallet-ui/react": "1.1.0-canary-20250617152337",
     "@wallet-ui/tailwind": "1.1.0-canary-20250617152337",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   community/gill-jito-airdrop:
     dependencies:
+      '@solana/kit':
+        specifier: ^2.3.0
+        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       '@tanstack/react-query':
         specifier: ^5.82.0
         version: 5.84.1(react@19.1.1)


### PR DESCRIPTION
This dependency is not imported directly in the code but the generated Codama client expects it.