### PR TITLE
chore: remove experimental flag for serverComponentsExternalPackages

### DIFF
--- a/community/gill-jito-airdrop/next.config.ts
+++ b/community/gill-jito-airdrop/next.config.ts
@@ -5,10 +5,9 @@ const nextConfig: NextConfig = {
     // Server-side environment variables that should be available at runtime
     USER_PRIVATE_KEY: process.env.USER_PRIVATE_KEY,
   },
-  experimental: {
-    // Enable server-side environment variables in client components when needed
-    serverComponentsExternalPackages: [],
-  },
+
+  // Enable server-side environment variables in client components when needed
+  serverComponentsExternalPackages: [],
 }
 
 export default nextConfig


### PR DESCRIPTION
The serverComponentsExternalPackages option is no longer experimental in Next.js, so it has been removed from the experimental configuration section.
Since the list was empty, this change introduces no functional changes to the code base.

Closing this PR — the flag name doesn’t exactly match the one documented in the official Next.js docs, so this change would not be correct.