### PR TITLE
chore: fix transaction toast

### DIFF
--- a/gill/gill-next-tailwind-basic/src/components/account/account-data-access.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/account/account-data-access.tsx
@@ -93,32 +93,25 @@ export function useTransferSolMutation({ address }: { address: Address }) {
 
   return useMutation({
     mutationFn: async (input: { destination: Address; amount: number }) => {
-      try {
-        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
+      const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
 
-        const transaction = createTransaction({
-          feePayer: signer,
-          version: 0,
-          latestBlockhash,
-          instructions: [
-            getTransferSolInstruction({
-              amount: input.amount,
-              destination: input.destination,
-              source: signer,
-            }),
-          ],
-        })
+      const transaction = createTransaction({ 
+        feePayer: signer,
+        version: 0,
+        latestBlockhash,
+        instructions: [
+          getTransferSolInstruction({
+            amount: input.amount,
+            destination: input.destination,
+            source: signer,
+          }),
+        ],
+      })
 
-        const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
-        const signature = getBase58Decoder().decode(signatureBytes)
-
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`)
-
-        return
-      }
+      const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
+      const signature = getBase58Decoder().decode(signatureBytes)
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (tx) => {
       toastTx(tx)
@@ -126,6 +119,7 @@ export function useTransferSolMutation({ address }: { address: Address }) {
     },
     onError: (error) => {
       toast.error(`Transaction failed! ${error}`)
+      console.error('Transaction failed:', error)
     },
   })
 }

--- a/gill/gill-next-tailwind-basic/src/components/app-layout.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/app-layout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/gill/gill-next-tailwind-basic/src/components/app-modal.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/gill/gill-next-tailwind-counter/src/components/account/account-data-access.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/account/account-data-access.tsx
@@ -93,32 +93,25 @@ export function useTransferSolMutation({ address }: { address: Address }) {
 
   return useMutation({
     mutationFn: async (input: { destination: Address; amount: number }) => {
-      try {
-        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
+      const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
 
-        const transaction = createTransaction({
-          feePayer: signer,
-          version: 0,
-          latestBlockhash,
-          instructions: [
-            getTransferSolInstruction({
-              amount: input.amount,
-              destination: input.destination,
-              source: signer,
-            }),
-          ],
-        })
+      const transaction = createTransaction({ 
+        feePayer: signer,
+        version: 0,
+        latestBlockhash,
+        instructions: [
+          getTransferSolInstruction({
+            amount: input.amount,
+            destination: input.destination,
+            source: signer,
+          }),
+        ],
+      })
 
-        const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
-        const signature = getBase58Decoder().decode(signatureBytes)
-
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`)
-
-        return
-      }
+      const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
+      const signature = getBase58Decoder().decode(signatureBytes)
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (tx) => {
       toastTx(tx)
@@ -126,6 +119,7 @@ export function useTransferSolMutation({ address }: { address: Address }) {
     },
     onError: (error) => {
       toast.error(`Transaction failed! ${error}`)
+      console.error('Transaction failed:', error)
     },
   })
 }

--- a/gill/gill-next-tailwind-counter/src/components/app-layout.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/app-layout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/gill/gill-next-tailwind-counter/src/components/app-modal.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/gill/gill-next-tailwind/src/components/account/account-data-access.tsx
+++ b/gill/gill-next-tailwind/src/components/account/account-data-access.tsx
@@ -93,32 +93,25 @@ export function useTransferSolMutation({ address }: { address: Address }) {
 
   return useMutation({
     mutationFn: async (input: { destination: Address; amount: number }) => {
-      try {
-        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
+      const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
 
-        const transaction = createTransaction({
-          feePayer: signer,
-          version: 0,
-          latestBlockhash,
-          instructions: [
-            getTransferSolInstruction({
-              amount: input.amount,
-              destination: input.destination,
-              source: signer,
-            }),
-          ],
-        })
+      const transaction = createTransaction({ 
+        feePayer: signer,
+        version: 0,
+        latestBlockhash,
+        instructions: [
+          getTransferSolInstruction({
+            amount: input.amount,
+            destination: input.destination,
+            source: signer,
+          }),
+        ],
+      })
 
-        const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
-        const signature = getBase58Decoder().decode(signatureBytes)
-
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`)
-
-        return
-      }
+      const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
+      const signature = getBase58Decoder().decode(signatureBytes)
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (tx) => {
       toastTx(tx)
@@ -126,6 +119,7 @@ export function useTransferSolMutation({ address }: { address: Address }) {
     },
     onError: (error) => {
       toast.error(`Transaction failed! ${error}`)
+      console.error('Transaction failed:', error)
     },
   })
 }

--- a/gill/gill-next-tailwind/src/components/app-layout.tsx
+++ b/gill/gill-next-tailwind/src/components/app-layout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/gill/gill-next-tailwind/src/components/app-modal.tsx
+++ b/gill/gill-next-tailwind/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/gill/gill-react-vite-tailwind-basic/src/components/account/account-data-access.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/account/account-data-access.tsx
@@ -93,32 +93,25 @@ export function useTransferSolMutation({ address }: { address: Address }) {
 
   return useMutation({
     mutationFn: async (input: { destination: Address; amount: number }) => {
-      try {
-        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
+      const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
 
-        const transaction = createTransaction({
-          feePayer: signer,
-          version: 0,
-          latestBlockhash,
-          instructions: [
-            getTransferSolInstruction({
-              amount: input.amount,
-              destination: input.destination,
-              source: signer,
-            }),
-          ],
-        })
+      const transaction = createTransaction({ 
+        feePayer: signer,
+        version: 0,
+        latestBlockhash,
+        instructions: [
+          getTransferSolInstruction({
+            amount: input.amount,
+            destination: input.destination,
+            source: signer,
+          }),
+        ],
+      })
 
-        const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
-        const signature = getBase58Decoder().decode(signatureBytes)
-
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`)
-
-        return
-      }
+      const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
+      const signature = getBase58Decoder().decode(signatureBytes)
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (tx) => {
       toastTx(tx)
@@ -126,6 +119,7 @@ export function useTransferSolMutation({ address }: { address: Address }) {
     },
     onError: (error) => {
       toast.error(`Transaction failed! ${error}`)
+      console.error('Transaction failed:', error)
     },
   })
 }

--- a/gill/gill-react-vite-tailwind-basic/src/components/app-layout.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/app-layout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/gill/gill-react-vite-tailwind-basic/src/components/app-modal.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/app-modal.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
-import React from 'react'
+import { ReactNode } from 'react'
 
 export function AppModal({
   children,
@@ -9,18 +9,23 @@ export function AppModal({
   submitDisabled,
   submitLabel,
 }: {
-  children: React.ReactNode
+  children: ReactNode
   title: string
   submit?: () => void
   submitDisabled?: boolean
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/gill/gill-react-vite-tailwind-counter/src/components/account/account-data-access.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/account/account-data-access.tsx
@@ -93,32 +93,25 @@ export function useTransferSolMutation({ address }: { address: Address }) {
 
   return useMutation({
     mutationFn: async (input: { destination: Address; amount: number }) => {
-      try {
-        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
+      const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
 
-        const transaction = createTransaction({
-          feePayer: signer,
-          version: 0,
-          latestBlockhash,
-          instructions: [
-            getTransferSolInstruction({
-              amount: input.amount,
-              destination: input.destination,
-              source: signer,
-            }),
-          ],
-        })
+      const transaction = createTransaction({ 
+        feePayer: signer,
+        version: 0,
+        latestBlockhash,
+        instructions: [
+          getTransferSolInstruction({
+            amount: input.amount,
+            destination: input.destination,
+            source: signer,
+          }),
+        ],
+      })
 
-        const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
-        const signature = getBase58Decoder().decode(signatureBytes)
-
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`)
-
-        return
-      }
+      const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
+      const signature = getBase58Decoder().decode(signatureBytes)
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (tx) => {
       toastTx(tx)
@@ -126,6 +119,7 @@ export function useTransferSolMutation({ address }: { address: Address }) {
     },
     onError: (error) => {
       toast.error(`Transaction failed! ${error}`)
+      console.error('Transaction failed:', error)
     },
   })
 }

--- a/gill/gill-react-vite-tailwind-counter/src/components/app-layout.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/app-layout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/gill/gill-react-vite-tailwind-counter/src/components/app-modal.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/app-modal.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
-import React from 'react'
+import { ReactNode } from 'react'
 
 export function AppModal({
   children,
@@ -9,18 +9,23 @@ export function AppModal({
   submitDisabled,
   submitLabel,
 }: {
-  children: React.ReactNode
+  children: ReactNode
   title: string
   submit?: () => void
   submitDisabled?: boolean
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/gill/gill-react-vite-tailwind/src/components/account/account-data-access.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/account/account-data-access.tsx
@@ -93,32 +93,25 @@ export function useTransferSolMutation({ address }: { address: Address }) {
 
   return useMutation({
     mutationFn: async (input: { destination: Address; amount: number }) => {
-      try {
-        const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
+      const { value: latestBlockhash } = await client.rpc.getLatestBlockhash({ commitment: 'confirmed' }).send()
 
-        const transaction = createTransaction({
-          feePayer: signer,
-          version: 0,
-          latestBlockhash,
-          instructions: [
-            getTransferSolInstruction({
-              amount: input.amount,
-              destination: input.destination,
-              source: signer,
-            }),
-          ],
-        })
+      const transaction = createTransaction({ 
+        feePayer: signer,
+        version: 0,
+        latestBlockhash,
+        instructions: [
+          getTransferSolInstruction({
+            amount: input.amount,
+            destination: input.destination,
+            source: signer,
+          }),
+        ],
+      })
 
-        const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
-        const signature = getBase58Decoder().decode(signatureBytes)
-
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`)
-
-        return
-      }
+      const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction)
+      const signature = getBase58Decoder().decode(signatureBytes)
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (tx) => {
       toastTx(tx)
@@ -126,6 +119,7 @@ export function useTransferSolMutation({ address }: { address: Address }) {
     },
     onError: (error) => {
       toast.error(`Transaction failed! ${error}`)
+      console.error('Transaction failed:', error)
     },
   })
 }

--- a/gill/gill-react-vite-tailwind/src/components/app-layout.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/app-layout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/gill/gill-react-vite-tailwind/src/components/app-modal.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/app-modal.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button'
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
-import React from 'react'
+import { ReactNode } from 'react'
 
 export function AppModal({
   children,
@@ -9,18 +9,23 @@ export function AppModal({
   submitDisabled,
   submitLabel,
 }: {
-  children: React.ReactNode
+  children: ReactNode
   title: string
   submit?: () => void
   submitDisabled?: boolean
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/web3js/web3js-next-tailwind-basic/src/components/app-layout.tsx
+++ b/web3js/web3js-next-tailwind-basic/src/components/app-layout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/web3js/web3js-next-tailwind-basic/src/components/app-modal.tsx
+++ b/web3js/web3js-next-tailwind-basic/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/web3js/web3js-next-tailwind-counter/src/components/app-layout.tsx
+++ b/web3js/web3js-next-tailwind-counter/src/components/app-layout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/web3js/web3js-next-tailwind-counter/src/components/app-modal.tsx
+++ b/web3js/web3js-next-tailwind-counter/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/web3js/web3js-next-tailwind/src/components/app-layout.tsx
+++ b/web3js/web3js-next-tailwind/src/components/app-layout.tsx
@@ -27,7 +27,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/web3js/web3js-next-tailwind/src/components/app-modal.tsx
+++ b/web3js/web3js-next-tailwind/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/web3js/web3js-next-tailwind/src/components/use-transaction-toast.tsx
+++ b/web3js/web3js-next-tailwind/src/components/use-transaction-toast.tsx
@@ -1,0 +1,10 @@
+import { toast } from 'sonner'
+import { ExplorerLink } from './cluster/cluster-ui'
+
+export function useTransactionToast() {
+  return (signature: string) => {
+    toast('Transaction sent', {
+      description: <ExplorerLink path={`tx/${signature}`} label="View Transaction" />,
+    })
+  }
+}

--- a/web3js/web3js-react-vite-tailwind-basic/src/components/account/account-data-access.tsx
+++ b/web3js/web3js-react-vite-tailwind-basic/src/components/account/account-data-access.tsx
@@ -10,6 +10,8 @@ import {
   VersionedTransaction,
 } from '@solana/web3.js'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useTransactionToast } from '../use-transaction-toast'
+import { toast } from 'sonner'
 
 export function useGetBalance({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
@@ -50,7 +52,7 @@ export function useGetTokenAccounts({ address }: { address: PublicKey }) {
 
 export function useTransferSol({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
-  // const transactionToast = useTransactionToast()
+  const transactionToast = useTransactionToast()
   const wallet = useWallet()
   const client = useQueryClient()
 
@@ -58,32 +60,25 @@ export function useTransferSol({ address }: { address: PublicKey }) {
     mutationKey: ['transfer-sol', { endpoint: connection.rpcEndpoint, address }],
     mutationFn: async (input: { destination: PublicKey; amount: number }) => {
       let signature: TransactionSignature = ''
-      try {
-        const { transaction, latestBlockhash } = await createTransaction({
-          publicKey: address,
-          destination: input.destination,
-          amount: input.amount,
-          connection,
-        })
+      const { transaction, latestBlockhash } = await createTransaction({
+        publicKey: address,
+        destination: input.destination,
+        amount: input.amount,
+        connection,
+      })
 
-        // Send transaction and await for signature
-        signature = await wallet.sendTransaction(transaction, connection)
+      // Send transaction and await for signature
+      signature = await wallet.sendTransaction(transaction, connection)
 
-        // Send transaction and await for signature
-        await connection.confirmTransaction({ signature, ...latestBlockhash }, 'confirmed')
+      // Send transaction and await for signature
+      await connection.confirmTransaction({ signature, ...latestBlockhash }, 'confirmed')
 
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`, signature)
-
-        return
-      }
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (signature) => {
       if (signature) {
-        // TODO: Add back Toast
-        // transactionToast(signature)
+        transactionToast(signature)
         console.log('Transaction sent', signature)
       }
       await Promise.all([
@@ -96,7 +91,7 @@ export function useTransferSol({ address }: { address: PublicKey }) {
       ])
     },
     onError: (error) => {
-      // TODO: Add Toast
+      toast.error(`Transaction failed! ${error}`)
       console.error(`Transaction failed! ${error}`)
     },
   })
@@ -104,7 +99,7 @@ export function useTransferSol({ address }: { address: PublicKey }) {
 
 export function useRequestAirdrop({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
-  // const transactionToast = useTransactionToast()
+  const transactionToast = useTransactionToast()
   const client = useQueryClient()
 
   return useMutation({
@@ -119,8 +114,7 @@ export function useRequestAirdrop({ address }: { address: PublicKey }) {
       return signature
     },
     onSuccess: async (signature) => {
-      // TODO: Add back Toast
-      // transactionToast(signature)
+      transactionToast(signature)
       console.log('Airdrop sent', signature)
       await Promise.all([
         client.invalidateQueries({

--- a/web3js/web3js-react-vite-tailwind-basic/src/components/app-layout.tsx
+++ b/web3js/web3js-react-vite-tailwind-basic/src/components/app-layout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/web3js/web3js-react-vite-tailwind-basic/src/components/app-modal.tsx
+++ b/web3js/web3js-react-vite-tailwind-basic/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/web3js/web3js-react-vite-tailwind-counter/src/components/account/account-data-access.tsx
+++ b/web3js/web3js-react-vite-tailwind-counter/src/components/account/account-data-access.tsx
@@ -10,6 +10,8 @@ import {
   VersionedTransaction,
 } from '@solana/web3.js'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useTransactionToast } from '../use-transaction-toast'
+import { toast } from 'sonner'
 
 export function useGetBalance({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
@@ -50,7 +52,7 @@ export function useGetTokenAccounts({ address }: { address: PublicKey }) {
 
 export function useTransferSol({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
-  // const transactionToast = useTransactionToast()
+  const transactionToast = useTransactionToast()
   const wallet = useWallet()
   const client = useQueryClient()
 
@@ -58,32 +60,25 @@ export function useTransferSol({ address }: { address: PublicKey }) {
     mutationKey: ['transfer-sol', { endpoint: connection.rpcEndpoint, address }],
     mutationFn: async (input: { destination: PublicKey; amount: number }) => {
       let signature: TransactionSignature = ''
-      try {
-        const { transaction, latestBlockhash } = await createTransaction({
-          publicKey: address,
-          destination: input.destination,
-          amount: input.amount,
-          connection,
-        })
+      const { transaction, latestBlockhash } = await createTransaction({
+        publicKey: address,
+        destination: input.destination,
+        amount: input.amount,
+        connection,
+      })
 
-        // Send transaction and await for signature
-        signature = await wallet.sendTransaction(transaction, connection)
+      // Send transaction and await for signature
+      signature = await wallet.sendTransaction(transaction, connection)
 
-        // Send transaction and await for signature
-        await connection.confirmTransaction({ signature, ...latestBlockhash }, 'confirmed')
+      // Send transaction and await for signature
+      await connection.confirmTransaction({ signature, ...latestBlockhash }, 'confirmed')
 
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`, signature)
-
-        return
-      }
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (signature) => {
       if (signature) {
-        // TODO: Add back Toast
-        // transactionToast(signature)
+        transactionToast(signature)
         console.log('Transaction sent', signature)
       }
       await Promise.all([
@@ -96,7 +91,7 @@ export function useTransferSol({ address }: { address: PublicKey }) {
       ])
     },
     onError: (error) => {
-      // TODO: Add Toast
+      toast.error(`Transaction failed! ${error}`)
       console.error(`Transaction failed! ${error}`)
     },
   })
@@ -104,7 +99,7 @@ export function useTransferSol({ address }: { address: PublicKey }) {
 
 export function useRequestAirdrop({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
-  // const transactionToast = useTransactionToast()
+  const transactionToast = useTransactionToast()
   const client = useQueryClient()
 
   return useMutation({
@@ -119,8 +114,7 @@ export function useRequestAirdrop({ address }: { address: PublicKey }) {
       return signature
     },
     onSuccess: async (signature) => {
-      // TODO: Add back Toast
-      // transactionToast(signature)
+      transactionToast(signature)
       console.log('Airdrop sent', signature)
       await Promise.all([
         client.invalidateQueries({

--- a/web3js/web3js-react-vite-tailwind-counter/src/components/app-layout.tsx
+++ b/web3js/web3js-react-vite-tailwind-counter/src/components/app-layout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/web3js/web3js-react-vite-tailwind-counter/src/components/app-modal.tsx
+++ b/web3js/web3js-react-vite-tailwind-counter/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/web3js/web3js-react-vite-tailwind/src/components/account/account-data-access.tsx
+++ b/web3js/web3js-react-vite-tailwind/src/components/account/account-data-access.tsx
@@ -10,6 +10,8 @@ import {
   VersionedTransaction,
 } from '@solana/web3.js'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useTransactionToast } from '../use-transaction-toast'
+import { toast } from 'sonner'
 
 export function useGetBalance({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
@@ -50,7 +52,7 @@ export function useGetTokenAccounts({ address }: { address: PublicKey }) {
 
 export function useTransferSol({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
-  // const transactionToast = useTransactionToast()
+  const transactionToast = useTransactionToast()
   const wallet = useWallet()
   const client = useQueryClient()
 
@@ -58,32 +60,25 @@ export function useTransferSol({ address }: { address: PublicKey }) {
     mutationKey: ['transfer-sol', { endpoint: connection.rpcEndpoint, address }],
     mutationFn: async (input: { destination: PublicKey; amount: number }) => {
       let signature: TransactionSignature = ''
-      try {
-        const { transaction, latestBlockhash } = await createTransaction({
-          publicKey: address,
-          destination: input.destination,
-          amount: input.amount,
-          connection,
-        })
+      const { transaction, latestBlockhash } = await createTransaction({
+        publicKey: address,
+        destination: input.destination,
+        amount: input.amount,
+        connection,
+      })
 
-        // Send transaction and await for signature
-        signature = await wallet.sendTransaction(transaction, connection)
+      // Send transaction and await for signature
+      signature = await wallet.sendTransaction(transaction, connection)
 
-        // Send transaction and await for signature
-        await connection.confirmTransaction({ signature, ...latestBlockhash }, 'confirmed')
+      // Send transaction and await for signature
+      await connection.confirmTransaction({ signature, ...latestBlockhash }, 'confirmed')
 
-        console.log(signature)
-        return signature
-      } catch (error: unknown) {
-        console.log('error', `Transaction failed! ${error}`, signature)
-
-        return
-      }
+      console.log('Transfer signature:', signature)
+      return signature
     },
     onSuccess: async (signature) => {
       if (signature) {
-        // TODO: Add back Toast
-        // transactionToast(signature)
+        transactionToast(signature)
         console.log('Transaction sent', signature)
       }
       await Promise.all([
@@ -96,7 +91,7 @@ export function useTransferSol({ address }: { address: PublicKey }) {
       ])
     },
     onError: (error) => {
-      // TODO: Add Toast
+      toast.error(`Transaction failed! ${error}`)
       console.error(`Transaction failed! ${error}`)
     },
   })
@@ -104,7 +99,7 @@ export function useTransferSol({ address }: { address: PublicKey }) {
 
 export function useRequestAirdrop({ address }: { address: PublicKey }) {
   const { connection } = useConnection()
-  // const transactionToast = useTransactionToast()
+  const transactionToast = useTransactionToast()
   const client = useQueryClient()
 
   return useMutation({
@@ -119,8 +114,7 @@ export function useRequestAirdrop({ address }: { address: PublicKey }) {
       return signature
     },
     onSuccess: async (signature) => {
-      // TODO: Add back Toast
-      // transactionToast(signature)
+      transactionToast(signature)
       console.log('Airdrop sent', signature)
       await Promise.all([
         client.invalidateQueries({

--- a/web3js/web3js-react-vite-tailwind/src/components/app-layout.tsx
+++ b/web3js/web3js-react-vite-tailwind/src/components/app-layout.tsx
@@ -25,7 +25,7 @@ export function AppLayout({
         </main>
         <AppFooter />
       </div>
-      <Toaster />
+      <Toaster closeButton />
     </ThemeProvider>
   )
 }

--- a/web3js/web3js-react-vite-tailwind/src/components/app-modal.tsx
+++ b/web3js/web3js-react-vite-tailwind/src/components/app-modal.tsx
@@ -16,11 +16,16 @@ export function AppModal({
   submitLabel?: string
 }) {
   return (
-    <Dialog>
+    <Dialog modal={false}>
       <DialogTrigger asChild>
         <Button variant="outline">{title}</Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[525px]">
+      <DialogContent className="sm:max-w-[525px]" onPointerDownOutside={(e) => {
+        const target = e.target as Element
+        if (target.closest('[data-sonner-toast]') || target.closest('.sonner-toast')) {
+          e.preventDefault()
+        }
+      }}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/web3js/web3js-react-vite-tailwind/src/components/use-transaction-toast.tsx
+++ b/web3js/web3js-react-vite-tailwind/src/components/use-transaction-toast.tsx
@@ -1,0 +1,10 @@
+import { toast } from 'sonner'
+import { ExplorerLink } from './cluster/cluster-ui'
+
+export function useTransactionToast() {
+  return (signature: string) => {
+    toast('Transaction sent', {
+      description: <ExplorerLink path={`tx/${signature}`} label="View Transaction" />,
+    })
+  }
+}


### PR DESCRIPTION
This PR closes issue #69 

### Bug:
1. Toast behind the App modal
2. No error toast showing in gill templates on send transaction failure but shows a console log
3. No success/error toast on send transaction in web3js templates

### Fixes:
- For bug 1 - 
  **Issue** - Both toast and AppModal have same z layer, clicking on toast activates AppModal close on outside click; **Solution** - Ignore close on outside click of AppModal if the click is on toast
- For **bug 2** - 
  **Issue** - try catch statement in mutation; **Solution** - removed try catch and let mutation itself return success or error on failure 
- For bug 3 - Implemented pending TODOs to add transactionToast and error toast