### PR TITLE
refactor: wrap use-wallet-ui hook in new use-solana hook

### DIFF
--- a/gill/gill-next-tailwind-basic/src/components/app-explorer-link.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/app-explorer-link.tsx
@@ -1,5 +1,5 @@
 import { getExplorerLink, GetExplorerLinkArgs } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function AppExplorerLink({
   className,
@@ -9,7 +9,7 @@ export function AppExplorerLink({
   className?: string
   label: string
 }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return (
     <a
       href={getExplorerLink({ ...link, cluster: cluster.cluster })}

--- a/gill/gill-next-tailwind-basic/src/components/solana/use-solana.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/solana/use-solana.tsx
@@ -1,0 +1,14 @@
+import { useWalletUi } from '@wallet-ui/react'
+
+/**
+ * Custom hook to abstract Wallet UI and related functionality from your app.
+ *
+ * This is a great place to add custom shared Solana logic or clients.
+ */
+export function useSolana() {
+  const walletUi = useWalletUi()
+
+  return {
+    ...walletUi,
+  }
+}

--- a/gill/gill-next-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
 import type { Instruction, TransactionSendingSigner } from 'gill'
 import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
+import { useSolana } from './use-solana'
 
 export function useWalletTransactionSignAndSend() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()

--- a/gill/gill-next-tailwind-basic/src/components/solana/use-wallet-ui-signer.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/solana/use-wallet-ui-signer.tsx
@@ -1,7 +1,8 @@
-import { UiWalletAccount, useWalletAccountTransactionSendingSigner, useWalletUi } from '@wallet-ui/react'
+import { UiWalletAccount, useWalletAccountTransactionSendingSigner } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useWalletUiSigner() {
-  const { account, cluster } = useWalletUi()
+  const { account, cluster } = useSolana()
 
   return useWalletAccountTransactionSendingSigner(account as UiWalletAccount, cluster.id)
 }

--- a/gill/gill-next-tailwind-basic/src/features/account/account-feature-index.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/account/account-feature-index.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 
 export default function AccountFeatureIndex({ redirect }: { redirect: (path: string) => ReactNode }) {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (account) {
     return redirect(`/account/${account.address.toString()}`)

--- a/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-balance-query-key.ts
+++ b/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-balance-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetBalanceQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-balance', { cluster, address }]
 }

--- a/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-balance-query.ts
+++ b/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-balance-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetBalanceQueryKey } from './use-get-balance-query-key'
 
 export function useGetBalanceQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     retry: false,

--- a/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-signatures-query-key.ts
+++ b/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-signatures-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetSignaturesQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-signatures', { cluster, address }]
 }

--- a/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-signatures-query.ts
+++ b/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-signatures-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetSignaturesQueryKey } from './use-get-signatures-query-key'
 
 export function useGetSignaturesQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useGetSignaturesQueryKey({ address }),

--- a/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-token-accounts-query.ts
+++ b/gill/gill-next-tailwind-basic/src/features/account/data-access/use-get-token-accounts-query.ts
@@ -1,11 +1,11 @@
 import type { Address } from 'gill'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from 'gill/programs/token'
-import { useWalletUi } from '@wallet-ui/react'
 import { useQuery } from '@tanstack/react-query'
 import { getTokenAccountsByOwner } from './get-token-accounts-by-owner'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetTokenAccountsQuery({ address }: { address: Address }) {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-token-accounts', { cluster, address }],

--- a/gill/gill-next-tailwind-basic/src/features/account/data-access/use-request-airdrop-mutation.ts
+++ b/gill/gill-next-tailwind-basic/src/features/account/data-access/use-request-airdrop-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { type Address, airdropFactory, lamports } from 'gill'
 import { toastTx } from '@/components/toast-tx'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useRequestAirdropMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })
   const airdrop = airdropFactory(client)

--- a/gill/gill-next-tailwind-basic/src/features/account/data-access/use-transfer-sol-mutation.ts
+++ b/gill/gill-next-tailwind-basic/src/features/account/data-access/use-transfer-sol-mutation.ts
@@ -2,14 +2,14 @@ import { Address, createTransaction, getBase58Decoder, signAndSendTransactionMes
 import { getTransferSolInstruction } from 'gill/programs'
 import { toast } from 'sonner'
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { toastTx } from '@/components/toast-tx'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useTransferSolMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const signer = useWalletUiSigner()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })

--- a/gill/gill-next-tailwind-basic/src/features/account/ui/account-ui-balance-check.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/account/ui/account-ui-balance-check.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AppAlert } from '@/components/app-alert'
 import { Button } from '@/components/ui/button'
 import { useRequestAirdropMutation } from '../data-access/use-request-airdrop-mutation'
 import { useGetBalanceQuery } from '../data-access/use-get-balance-query'
 
 export function AccountUiBalanceCheck({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const mutation = useRequestAirdropMutation({ address })
   const query = useGetBalanceQuery({ address })
 

--- a/gill/gill-next-tailwind-basic/src/features/account/ui/account-ui-buttons.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/account/ui/account-ui-buttons.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
 import { ErrorBoundary } from 'next/dist/client/components/error-boundary'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AccountUiModalAirdrop } from './account-ui-modal-airdrop'
 import { AccountUiModalReceive } from './account-ui-modal-receive'
 import { AccountUiModalSend } from './account-ui-modal-send'
 
 export function AccountUiButtons({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return (
     <div>

--- a/gill/gill-next-tailwind-basic/src/features/account/ui/account-ui-checker.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/account/ui/account-ui-checker.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { address } from 'gill'
 import { AccountUiBalanceCheck } from './account-ui-balance-check'
 
 export function AccountUiChecker() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
   if (!account) {
     return null
   }

--- a/gill/gill-next-tailwind-basic/src/features/basic/basic-feature.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/basic/basic-feature.tsx
@@ -1,4 +1,4 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 import { AppHero } from '@/components/app-hero'
 import { BasicUiProgramExplorerLink } from './ui/basic-ui-program-explorer-link'
@@ -6,7 +6,7 @@ import { BasicUiCreate } from './ui/basic-ui-create'
 import { BasicUiProgram } from '@/features/basic/ui/basic-ui-program'
 
 export default function BasicFeature() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (!account) {
     return (

--- a/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
+++ b/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useMemo } from 'react'
 import { getBasicProgramId } from '@project/anchor'
 
 export function useBasicProgramId() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return useMemo(() => getBasicProgramId(cluster.id), [cluster])
 }

--- a/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
+++ b/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getBasicProgramId } from '@project/anchor'
 
 export function useGetProgramAccountQuery() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-program-account', { cluster }],

--- a/gill/gill-next-tailwind-basic/src/features/cluster/data-access/use-cluster-version.ts
+++ b/gill/gill-next-tailwind-basic/src/features/cluster/data-access/use-cluster-version.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 
 export function useClusterVersion() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   return useQuery({
     retry: false,
     queryKey: ['version', { cluster }],

--- a/gill/gill-next-tailwind-basic/src/features/cluster/ui/cluster-ui-checker.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/cluster/ui/cluster-ui-checker.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { AppAlert } from '@/components/app-alert'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useClusterVersion } from '../data-access/use-cluster-version'
 
 export function ClusterUiChecker({ children }: { children: ReactNode }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const query = useClusterVersion()
 
   if (query.isLoading) {

--- a/gill/gill-next-tailwind-counter/src/components/app-explorer-link.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/app-explorer-link.tsx
@@ -1,5 +1,5 @@
 import { getExplorerLink, GetExplorerLinkArgs } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function AppExplorerLink({
   className,
@@ -9,7 +9,7 @@ export function AppExplorerLink({
   className?: string
   label: string
 }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return (
     <a
       href={getExplorerLink({ ...link, cluster: cluster.cluster })}

--- a/gill/gill-next-tailwind-counter/src/components/solana/use-solana.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/solana/use-solana.tsx
@@ -1,0 +1,14 @@
+import { useWalletUi } from '@wallet-ui/react'
+
+/**
+ * Custom hook to abstract Wallet UI and related functionality from your app.
+ *
+ * This is a great place to add custom shared Solana logic or clients.
+ */
+export function useSolana() {
+  const walletUi = useWalletUi()
+
+  return {
+    ...walletUi,
+  }
+}

--- a/gill/gill-next-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
 import type { Instruction, TransactionSendingSigner } from 'gill'
 import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
+import { useSolana } from './use-solana'
 
 export function useWalletTransactionSignAndSend() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()

--- a/gill/gill-next-tailwind-counter/src/components/solana/use-wallet-ui-signer.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/solana/use-wallet-ui-signer.tsx
@@ -1,7 +1,8 @@
-import { UiWalletAccount, useWalletAccountTransactionSendingSigner, useWalletUi } from '@wallet-ui/react'
+import { UiWalletAccount, useWalletAccountTransactionSendingSigner } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useWalletUiSigner() {
-  const { account, cluster } = useWalletUi()
+  const { account, cluster } = useSolana()
 
   return useWalletAccountTransactionSendingSigner(account as UiWalletAccount, cluster.id)
 }

--- a/gill/gill-next-tailwind-counter/src/features/account/account-feature-index.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/account/account-feature-index.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 
 export default function AccountFeatureIndex({ redirect }: { redirect: (path: string) => ReactNode }) {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (account) {
     return redirect(`/account/${account.address.toString()}`)

--- a/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-balance-query-key.ts
+++ b/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-balance-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetBalanceQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-balance', { cluster, address }]
 }

--- a/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-balance-query.ts
+++ b/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-balance-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetBalanceQueryKey } from './use-get-balance-query-key'
 
 export function useGetBalanceQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     retry: false,

--- a/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-signatures-query-key.ts
+++ b/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-signatures-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetSignaturesQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-signatures', { cluster, address }]
 }

--- a/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-signatures-query.ts
+++ b/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-signatures-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetSignaturesQueryKey } from './use-get-signatures-query-key'
 
 export function useGetSignaturesQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useGetSignaturesQueryKey({ address }),

--- a/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-token-accounts-query.ts
+++ b/gill/gill-next-tailwind-counter/src/features/account/data-access/use-get-token-accounts-query.ts
@@ -1,11 +1,11 @@
 import type { Address } from 'gill'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from 'gill/programs/token'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getTokenAccountsByOwner } from './get-token-accounts-by-owner'
 
 export function useGetTokenAccountsQuery({ address }: { address: Address }) {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-token-accounts', { cluster, address }],

--- a/gill/gill-next-tailwind-counter/src/features/account/data-access/use-request-airdrop-mutation.ts
+++ b/gill/gill-next-tailwind-counter/src/features/account/data-access/use-request-airdrop-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { type Address, airdropFactory, lamports } from 'gill'
 import { toastTx } from '@/components/toast-tx'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useRequestAirdropMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })
   const airdrop = airdropFactory(client)

--- a/gill/gill-next-tailwind-counter/src/features/account/data-access/use-transfer-sol-mutation.ts
+++ b/gill/gill-next-tailwind-counter/src/features/account/data-access/use-transfer-sol-mutation.ts
@@ -2,14 +2,14 @@ import { Address, createTransaction, getBase58Decoder, signAndSendTransactionMes
 import { getTransferSolInstruction } from 'gill/programs'
 import { toast } from 'sonner'
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { toastTx } from '@/components/toast-tx'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useTransferSolMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const signer = useWalletUiSigner()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })

--- a/gill/gill-next-tailwind-counter/src/features/account/ui/account-ui-balance-check.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/account/ui/account-ui-balance-check.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AppAlert } from '@/components/app-alert'
 import { Button } from '@/components/ui/button'
 import { useRequestAirdropMutation } from '../data-access/use-request-airdrop-mutation'
 import { useGetBalanceQuery } from '../data-access/use-get-balance-query'
 
 export function AccountUiBalanceCheck({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const mutation = useRequestAirdropMutation({ address })
   const query = useGetBalanceQuery({ address })
 

--- a/gill/gill-next-tailwind-counter/src/features/account/ui/account-ui-buttons.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/account/ui/account-ui-buttons.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
 import { ErrorBoundary } from 'next/dist/client/components/error-boundary'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AccountUiModalAirdrop } from './account-ui-modal-airdrop'
 import { AccountUiModalReceive } from './account-ui-modal-receive'
 import { AccountUiModalSend } from './account-ui-modal-send'
 
 export function AccountUiButtons({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return (
     <div>

--- a/gill/gill-next-tailwind-counter/src/features/account/ui/account-ui-checker.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/account/ui/account-ui-checker.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { address } from 'gill'
 import { AccountUiBalanceCheck } from './account-ui-balance-check'
 
 export function AccountUiChecker() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
   if (!account) {
     return null
   }

--- a/gill/gill-next-tailwind-counter/src/features/cluster/data-access/use-cluster-version.ts
+++ b/gill/gill-next-tailwind-counter/src/features/cluster/data-access/use-cluster-version.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 
 export function useClusterVersion() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   return useQuery({
     retry: false,
     queryKey: ['version', { cluster }],

--- a/gill/gill-next-tailwind-counter/src/features/cluster/ui/cluster-ui-checker.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/cluster/ui/cluster-ui-checker.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { AppAlert } from '@/components/app-alert'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useClusterVersion } from '../data-access/use-cluster-version'
 
 export function ClusterUiChecker({ children }: { children: ReactNode }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const query = useClusterVersion()
 
   if (query.isLoading) {

--- a/gill/gill-next-tailwind-counter/src/features/counter/counter-feature.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/counter/counter-feature.tsx
@@ -1,4 +1,4 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 import { AppHero } from '@/components/app-hero'
 import { CounterUiButtonInitialize } from './ui/counter-ui-button-initialize'
@@ -7,7 +7,7 @@ import { CounterUiProgramExplorerLink } from './ui/counter-ui-program-explorer-l
 import { CounterUiProgramGuard } from './ui/counter-ui-program-guard'
 
 export default function CounterFeature() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   return (
     <CounterUiProgramGuard>

--- a/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query-key.ts
+++ b/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query-key.ts
@@ -1,7 +1,7 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useCounterAccountsQueryKey() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['counter', 'accounts', { cluster }]
 }

--- a/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query.ts
+++ b/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query.ts
@@ -1,10 +1,10 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getCounterProgramAccounts } from '@project/anchor'
 import { useCounterAccountsQueryKey } from './use-counter-accounts-query-key'
 
 export function useCounterAccountsQuery() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useCounterAccountsQueryKey(),

--- a/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-initialize-mutation.ts
+++ b/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-initialize-mutation.ts
@@ -1,4 +1,4 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useWalletTransactionSignAndSend } from '@/components/solana/use-wallet-transaction-sign-and-send'
@@ -12,7 +12,7 @@ import { toast } from 'sonner'
 installEd25519()
 
 export function useCounterInitializeMutation() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const queryClient = useQueryClient()
   const signer = useWalletUiSigner()
   const signAndSend = useWalletTransactionSignAndSend()

--- a/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
+++ b/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useMemo } from 'react'
 import { getCounterProgramId } from '@project/anchor'
 
 export function useCounterProgramId() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return useMemo(() => getCounterProgramId(cluster.id), [cluster])
 }

--- a/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
+++ b/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
@@ -1,10 +1,10 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useClusterVersion } from '@/features/cluster/data-access/use-cluster-version'
 import { useCounterProgramId } from './use-counter-program-id'
 
 export function useCounterProgram() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   const programId = useCounterProgramId()
   const query = useClusterVersion()
 

--- a/gill/gill-next-tailwind/src/components/app-explorer-link.tsx
+++ b/gill/gill-next-tailwind/src/components/app-explorer-link.tsx
@@ -1,5 +1,5 @@
 import { getExplorerLink, GetExplorerLinkArgs } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function AppExplorerLink({
   className,
@@ -9,7 +9,7 @@ export function AppExplorerLink({
   className?: string
   label: string
 }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return (
     <a
       href={getExplorerLink({ ...link, cluster: cluster.cluster })}

--- a/gill/gill-next-tailwind/src/components/solana/use-solana.tsx
+++ b/gill/gill-next-tailwind/src/components/solana/use-solana.tsx
@@ -1,0 +1,14 @@
+import { useWalletUi } from '@wallet-ui/react'
+
+/**
+ * Custom hook to abstract Wallet UI and related functionality from your app.
+ *
+ * This is a great place to add custom shared Solana logic or clients.
+ */
+export function useSolana() {
+  const walletUi = useWalletUi()
+
+  return {
+    ...walletUi,
+  }
+}

--- a/gill/gill-next-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/gill/gill-next-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
 import type { Instruction, TransactionSendingSigner } from 'gill'
 import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
+import { useSolana } from './use-solana'
 
 export function useWalletTransactionSignAndSend() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()

--- a/gill/gill-next-tailwind/src/components/solana/use-wallet-ui-signer.tsx
+++ b/gill/gill-next-tailwind/src/components/solana/use-wallet-ui-signer.tsx
@@ -1,7 +1,8 @@
-import { UiWalletAccount, useWalletAccountTransactionSendingSigner, useWalletUi } from '@wallet-ui/react'
+import { UiWalletAccount, useWalletAccountTransactionSendingSigner } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useWalletUiSigner() {
-  const { account, cluster } = useWalletUi()
+  const { account, cluster } = useSolana()
 
   return useWalletAccountTransactionSendingSigner(account as UiWalletAccount, cluster.id)
 }

--- a/gill/gill-next-tailwind/src/features/account/account-feature-index.tsx
+++ b/gill/gill-next-tailwind/src/features/account/account-feature-index.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react'
-import { useWalletUi } from '@wallet-ui/react'
 import { WalletButton } from '@/components/solana/solana-provider'
+import { useSolana } from '@/components/solana/use-solana'
 
 export default function AccountFeatureIndex({ redirect }: { redirect: (path: string) => ReactNode }) {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (account) {
     return redirect(`/account/${account.address.toString()}`)

--- a/gill/gill-next-tailwind/src/features/account/data-access/use-get-balance-query-key.ts
+++ b/gill/gill-next-tailwind/src/features/account/data-access/use-get-balance-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetBalanceQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-balance', { cluster, address }]
 }

--- a/gill/gill-next-tailwind/src/features/account/data-access/use-get-balance-query.ts
+++ b/gill/gill-next-tailwind/src/features/account/data-access/use-get-balance-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
 import { useQuery } from '@tanstack/react-query'
+import { useSolana } from '@/components/solana/use-solana'
 import { useGetBalanceQueryKey } from './use-get-balance-query-key'
 
 export function useGetBalanceQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     retry: false,

--- a/gill/gill-next-tailwind/src/features/account/data-access/use-get-signatures-query-key.ts
+++ b/gill/gill-next-tailwind/src/features/account/data-access/use-get-signatures-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetSignaturesQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-signatures', { cluster, address }]
 }

--- a/gill/gill-next-tailwind/src/features/account/data-access/use-get-signatures-query.ts
+++ b/gill/gill-next-tailwind/src/features/account/data-access/use-get-signatures-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
 import { useQuery } from '@tanstack/react-query'
+import { useSolana } from '@/components/solana/use-solana'
 import { useGetSignaturesQueryKey } from './use-get-signatures-query-key'
 
 export function useGetSignaturesQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useGetSignaturesQueryKey({ address }),

--- a/gill/gill-next-tailwind/src/features/account/data-access/use-get-token-accounts-query.ts
+++ b/gill/gill-next-tailwind/src/features/account/data-access/use-get-token-accounts-query.ts
@@ -1,11 +1,11 @@
 import type { Address } from 'gill'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from 'gill/programs/token'
-import { useWalletUi } from '@wallet-ui/react'
 import { useQuery } from '@tanstack/react-query'
+import { useSolana } from '@/components/solana/use-solana'
 import { getTokenAccountsByOwner } from './get-token-accounts-by-owner'
 
 export function useGetTokenAccountsQuery({ address }: { address: Address }) {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-token-accounts', { cluster, address }],

--- a/gill/gill-next-tailwind/src/features/account/data-access/use-request-airdrop-mutation.ts
+++ b/gill/gill-next-tailwind/src/features/account/data-access/use-request-airdrop-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
 import { type Address, airdropFactory, lamports } from 'gill'
+import { useSolana } from '@/components/solana/use-solana'
 import { toastTx } from '@/components/toast-tx'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useRequestAirdropMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })
   const airdrop = airdropFactory(client)

--- a/gill/gill-next-tailwind/src/features/account/data-access/use-transfer-sol-mutation.ts
+++ b/gill/gill-next-tailwind/src/features/account/data-access/use-transfer-sol-mutation.ts
@@ -2,14 +2,14 @@ import { Address, createTransaction, getBase58Decoder, signAndSendTransactionMes
 import { getTransferSolInstruction } from 'gill/programs'
 import { toast } from 'sonner'
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
 import { toastTx } from '@/components/toast-tx'
+import { useSolana } from '@/components/solana/use-solana'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useTransferSolMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const signer = useWalletUiSigner()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })

--- a/gill/gill-next-tailwind/src/features/account/ui/account-ui-balance-check.tsx
+++ b/gill/gill-next-tailwind/src/features/account/ui/account-ui-balance-check.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
 import { AppAlert } from '@/components/app-alert'
 import { Button } from '@/components/ui/button'
+import { useSolana } from '@/components/solana/use-solana'
 import { useRequestAirdropMutation } from '../data-access/use-request-airdrop-mutation'
 import { useGetBalanceQuery } from '../data-access/use-get-balance-query'
 
 export function AccountUiBalanceCheck({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const mutation = useRequestAirdropMutation({ address })
   const query = useGetBalanceQuery({ address })
 

--- a/gill/gill-next-tailwind/src/features/account/ui/account-ui-buttons.tsx
+++ b/gill/gill-next-tailwind/src/features/account/ui/account-ui-buttons.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
 import { ErrorBoundary } from 'next/dist/client/components/error-boundary'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AccountUiModalAirdrop } from './account-ui-modal-airdrop'
 import { AccountUiModalReceive } from './account-ui-modal-receive'
 import { AccountUiModalSend } from './account-ui-modal-send'
 
 export function AccountUiButtons({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return (
     <div>

--- a/gill/gill-next-tailwind/src/features/account/ui/account-ui-checker.tsx
+++ b/gill/gill-next-tailwind/src/features/account/ui/account-ui-checker.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
 import { address } from 'gill'
+import { useSolana } from '@/components/solana/use-solana'
 import { AccountUiBalanceCheck } from './account-ui-balance-check'
 
 export function AccountUiChecker() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
   if (!account) {
     return null
   }

--- a/gill/gill-next-tailwind/src/features/cluster/data-access/use-cluster-version.ts
+++ b/gill/gill-next-tailwind/src/features/cluster/data-access/use-cluster-version.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
 import { useQuery } from '@tanstack/react-query'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useClusterVersion() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   return useQuery({
     retry: false,
     queryKey: ['version', { cluster }],

--- a/gill/gill-next-tailwind/src/features/cluster/ui/cluster-ui-checker.tsx
+++ b/gill/gill-next-tailwind/src/features/cluster/ui/cluster-ui-checker.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { AppAlert } from '@/components/app-alert'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useClusterVersion } from '../data-access/use-cluster-version'
 
 export function ClusterUiChecker({ children }: { children: ReactNode }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const query = useClusterVersion()
 
   if (query.isLoading) {

--- a/gill/gill-react-vite-tailwind-basic/src/components/app-explorer-link.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/app-explorer-link.tsx
@@ -1,5 +1,5 @@
 import { getExplorerLink, GetExplorerLinkArgs } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function AppExplorerLink({
   className,
@@ -9,7 +9,7 @@ export function AppExplorerLink({
   className?: string
   label: string
 }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return (
     <a
       href={getExplorerLink({ ...link, cluster: cluster.cluster })}

--- a/gill/gill-react-vite-tailwind-basic/src/components/solana/use-solana.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/solana/use-solana.tsx
@@ -1,0 +1,14 @@
+import { useWalletUi } from '@wallet-ui/react'
+
+/**
+ * Custom hook to abstract Wallet UI and related functionality from your app.
+ *
+ * This is a great place to add custom shared Solana logic or clients.
+ */
+export function useSolana() {
+  const walletUi = useWalletUi()
+
+  return {
+    ...walletUi,
+  }
+}

--- a/gill/gill-react-vite-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
 import type { Instruction, TransactionSendingSigner } from 'gill'
 import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
+import { useSolana } from './use-solana'
 
 export function useWalletTransactionSignAndSend() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()

--- a/gill/gill-react-vite-tailwind-basic/src/components/solana/use-wallet-ui-signer.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/solana/use-wallet-ui-signer.tsx
@@ -1,7 +1,8 @@
-import { UiWalletAccount, useWalletAccountTransactionSendingSigner, useWalletUi } from '@wallet-ui/react'
+import { UiWalletAccount, useWalletAccountTransactionSendingSigner } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useWalletUiSigner() {
-  const { account, cluster } = useWalletUi()
+  const { account, cluster } = useSolana()
 
   return useWalletAccountTransactionSendingSigner(account as UiWalletAccount, cluster.id)
 }

--- a/gill/gill-react-vite-tailwind-basic/src/components/use-transaction-toast.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/use-transaction-toast.tsx
@@ -1,5 +1,5 @@
 import { toast } from 'sonner'
-import { AppExplorerLink } from '@/components/app-explorer-link.tsx'
+import { AppExplorerLink } from './app-explorer-link.tsx'
 
 export function useTransactionToast() {
   return (signature: string) => {

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/account-feature-index.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/account-feature-index.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 import { Navigate } from 'react-router'
 
 export default function AccountFeatureIndex() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (account) {
     return <Navigate to={`/account/${account.address.toString()}`} replace />

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-balance-query-key.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-balance-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetBalanceQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-balance', { cluster, address }]
 }

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-balance-query.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-balance-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetBalanceQueryKey } from './use-get-balance-query-key'
 
 export function useGetBalanceQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     retry: false,

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-signatures-query-key.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-signatures-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetSignaturesQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-signatures', { cluster, address }]
 }

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-signatures-query.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-signatures-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetSignaturesQueryKey } from './use-get-signatures-query-key'
 
 export function useGetSignaturesQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useGetSignaturesQueryKey({ address }),

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-token-accounts-query.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-get-token-accounts-query.ts
@@ -1,11 +1,11 @@
 import type { Address } from 'gill'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from 'gill/programs/token'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getTokenAccountsByOwner } from './get-token-accounts-by-owner'
 
 export function useGetTokenAccountsQuery({ address }: { address: Address }) {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-token-accounts', { cluster, address }],

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-request-airdrop-mutation.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-request-airdrop-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { type Address, airdropFactory, lamports } from 'gill'
 import { toastTx } from '@/components/toast-tx'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useRequestAirdropMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })
   const airdrop = airdropFactory(client)

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-transfer-sol-mutation.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/data-access/use-transfer-sol-mutation.ts
@@ -2,14 +2,14 @@ import { Address, createTransaction, getBase58Decoder, signAndSendTransactionMes
 import { getTransferSolInstruction } from 'gill/programs'
 import { toast } from 'sonner'
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { toastTx } from '@/components/toast-tx'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useTransferSolMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const signer = useWalletUiSigner()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/ui/account-ui-balance-check.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/ui/account-ui-balance-check.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AppAlert } from '@/components/app-alert'
 import { Button } from '@/components/ui/button'
 import { useRequestAirdropMutation } from '../data-access/use-request-airdrop-mutation'
 import { useGetBalanceQuery } from '../data-access/use-get-balance-query'
 
 export function AccountUiBalanceCheck({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const mutation = useRequestAirdropMutation({ address })
   const query = useGetBalanceQuery({ address })
 

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/ui/account-ui-buttons.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/ui/account-ui-buttons.tsx
@@ -1,13 +1,13 @@
 import { Address } from 'gill'
 
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AccountUiModalAirdrop } from './account-ui-modal-airdrop'
 import { AccountUiModalReceive } from './account-ui-modal-receive'
 import { AccountUiModalSend } from './account-ui-modal-send'
 import { ErrorBoundary } from 'react-error-boundary'
 
 export function AccountUiButtons({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return (
     <div>

--- a/gill/gill-react-vite-tailwind-basic/src/features/account/ui/account-ui-checker.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/account/ui/account-ui-checker.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { address } from 'gill'
 import { AccountUiBalanceCheck } from './account-ui-balance-check'
 
 export function AccountUiChecker() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
   if (!account) {
     return null
   }

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/basic-feature.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/basic-feature.tsx
@@ -1,4 +1,4 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 import { AppHero } from '@/components/app-hero'
 import { BasicUiProgramExplorerLink } from './ui/basic-ui-program-explorer-link'
@@ -6,7 +6,7 @@ import { BasicUiCreate } from './ui/basic-ui-create'
 import { BasicUiProgram } from '@/features/basic/ui/basic-ui-program'
 
 export default function BasicFeature() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (!account) {
     return (

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useMemo } from 'react'
 import { getBasicProgramId } from '@project/anchor'
 
 export function useBasicProgramId() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return useMemo(() => getBasicProgramId(cluster.id), [cluster])
 }

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getBasicProgramId } from '@project/anchor'
 
 export function useGetProgramAccountQuery() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-program-account', { cluster }],

--- a/gill/gill-react-vite-tailwind-basic/src/features/cluster/data-access/use-cluster-version.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/cluster/data-access/use-cluster-version.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 
 export function useClusterVersion() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   return useQuery({
     retry: false,
     queryKey: ['version', { cluster }],

--- a/gill/gill-react-vite-tailwind-basic/src/features/cluster/ui/cluster-ui-checker.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/cluster/ui/cluster-ui-checker.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { AppAlert } from '@/components/app-alert'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useClusterVersion } from '../data-access/use-cluster-version'
 
 export function ClusterUiChecker({ children }: { children: ReactNode }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const query = useClusterVersion()
 
   if (query.isLoading) {

--- a/gill/gill-react-vite-tailwind-counter/src/components/app-explorer-link.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/app-explorer-link.tsx
@@ -1,5 +1,5 @@
 import { getExplorerLink, GetExplorerLinkArgs } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function AppExplorerLink({
   className,
@@ -9,7 +9,7 @@ export function AppExplorerLink({
   className?: string
   label: string
 }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return (
     <a
       href={getExplorerLink({ ...link, cluster: cluster.cluster })}

--- a/gill/gill-react-vite-tailwind-counter/src/components/solana/use-solana.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/solana/use-solana.tsx
@@ -1,0 +1,14 @@
+import { useWalletUi } from '@wallet-ui/react'
+
+/**
+ * Custom hook to abstract Wallet UI and related functionality from your app.
+ *
+ * This is a great place to add custom shared Solana logic or clients.
+ */
+export function useSolana() {
+  const walletUi = useWalletUi()
+
+  return {
+    ...walletUi,
+  }
+}

--- a/gill/gill-react-vite-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
 import type { Instruction, TransactionSendingSigner } from 'gill'
 import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
+import { useSolana } from './use-solana'
 
 export function useWalletTransactionSignAndSend() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()

--- a/gill/gill-react-vite-tailwind-counter/src/components/solana/use-wallet-ui-signer.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/solana/use-wallet-ui-signer.tsx
@@ -1,7 +1,8 @@
-import { UiWalletAccount, useWalletAccountTransactionSendingSigner, useWalletUi } from '@wallet-ui/react'
+import { UiWalletAccount, useWalletAccountTransactionSendingSigner } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useWalletUiSigner() {
-  const { account, cluster } = useWalletUi()
+  const { account, cluster } = useSolana()
 
   return useWalletAccountTransactionSendingSigner(account as UiWalletAccount, cluster.id)
 }

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/account-feature-index.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/account-feature-index.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 import { Navigate } from 'react-router'
 
 export default function AccountFeatureIndex() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (account) {
     return <Navigate to={`/account/${account.address.toString()}`} replace />

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-balance-query-key.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-balance-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetBalanceQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-balance', { cluster, address }]
 }

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-balance-query.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-balance-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetBalanceQueryKey } from './use-get-balance-query-key'
 
 export function useGetBalanceQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     retry: false,

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-signatures-query-key.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-signatures-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetSignaturesQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-signatures', { cluster, address }]
 }

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-signatures-query.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-signatures-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetSignaturesQueryKey } from './use-get-signatures-query-key'
 
 export function useGetSignaturesQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useGetSignaturesQueryKey({ address }),

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-token-accounts-query.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-get-token-accounts-query.ts
@@ -1,11 +1,11 @@
 import type { Address } from 'gill'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from 'gill/programs/token'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getTokenAccountsByOwner } from './get-token-accounts-by-owner'
 
 export function useGetTokenAccountsQuery({ address }: { address: Address }) {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-token-accounts', { cluster, address }],

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-request-airdrop-mutation.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-request-airdrop-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { type Address, airdropFactory, lamports } from 'gill'
 import { toastTx } from '@/components/toast-tx'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useRequestAirdropMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })
   const airdrop = airdropFactory(client)

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-transfer-sol-mutation.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/data-access/use-transfer-sol-mutation.ts
@@ -2,14 +2,14 @@ import { Address, createTransaction, getBase58Decoder, signAndSendTransactionMes
 import { getTransferSolInstruction } from 'gill/programs'
 import { toast } from 'sonner'
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { toastTx } from '@/components/toast-tx'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useTransferSolMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const signer = useWalletUiSigner()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/ui/account-ui-balance-check.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/ui/account-ui-balance-check.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AppAlert } from '@/components/app-alert'
 import { Button } from '@/components/ui/button'
 import { useRequestAirdropMutation } from '../data-access/use-request-airdrop-mutation'
 import { useGetBalanceQuery } from '../data-access/use-get-balance-query'
 
 export function AccountUiBalanceCheck({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const mutation = useRequestAirdropMutation({ address })
   const query = useGetBalanceQuery({ address })
 

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/ui/account-ui-buttons.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/ui/account-ui-buttons.tsx
@@ -1,13 +1,13 @@
 import { Address } from 'gill'
 
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AccountUiModalAirdrop } from './account-ui-modal-airdrop'
 import { AccountUiModalReceive } from './account-ui-modal-receive'
 import { AccountUiModalSend } from './account-ui-modal-send'
 import { ErrorBoundary } from 'react-error-boundary'
 
 export function AccountUiButtons({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return (
     <div>

--- a/gill/gill-react-vite-tailwind-counter/src/features/account/ui/account-ui-checker.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/account/ui/account-ui-checker.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { address } from 'gill'
 import { AccountUiBalanceCheck } from './account-ui-balance-check'
 
 export function AccountUiChecker() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
   if (!account) {
     return null
   }

--- a/gill/gill-react-vite-tailwind-counter/src/features/cluster/data-access/use-cluster-version.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/cluster/data-access/use-cluster-version.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 
 export function useClusterVersion() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   return useQuery({
     retry: false,
     queryKey: ['version', { cluster }],

--- a/gill/gill-react-vite-tailwind-counter/src/features/cluster/ui/cluster-ui-checker.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/cluster/ui/cluster-ui-checker.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { AppAlert } from '@/components/app-alert'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useClusterVersion } from '../data-access/use-cluster-version'
 
 export function ClusterUiChecker({ children }: { children: ReactNode }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const query = useClusterVersion()
 
   if (query.isLoading) {

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/counter-feature.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/counter-feature.tsx
@@ -1,4 +1,4 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 import { AppHero } from '@/components/app-hero'
 import { CounterUiButtonInitialize } from './ui/counter-ui-button-initialize'
@@ -7,7 +7,7 @@ import { CounterUiProgramExplorerLink } from './ui/counter-ui-program-explorer-l
 import { CounterUiProgramGuard } from './ui/counter-ui-program-guard'
 
 export default function CounterFeature() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   return (
     <CounterUiProgramGuard>

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query-key.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query-key.ts
@@ -1,7 +1,7 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useCounterAccountsQueryKey() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['counter', 'accounts', { cluster }]
 }

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-accounts-query.ts
@@ -1,10 +1,10 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getCounterProgramAccounts } from '@project/anchor'
 import { useCounterAccountsQueryKey } from './use-counter-accounts-query-key'
 
 export function useCounterAccountsQuery() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useCounterAccountsQueryKey(),

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-initialize-mutation.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-initialize-mutation.ts
@@ -1,4 +1,4 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useWalletTransactionSignAndSend } from '@/components/solana/use-wallet-transaction-sign-and-send'
@@ -12,7 +12,7 @@ import { toast } from 'sonner'
 installEd25519()
 
 export function useCounterInitializeMutation() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const queryClient = useQueryClient()
   const signer = useWalletUiSigner()
   const signAndSend = useWalletTransactionSignAndSend()

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
 import { useMemo } from 'react'
 import { getCounterProgramId } from '@project/anchor'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useCounterProgramId() {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return useMemo(() => getCounterProgramId(cluster.id), [cluster])
 }

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
@@ -1,10 +1,10 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useClusterVersion } from '@/features/cluster/data-access/use-cluster-version'
 import { useCounterProgramId } from './use-counter-program-id'
 
 export function useCounterProgram() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   const programId = useCounterProgramId()
   const query = useClusterVersion()
 

--- a/gill/gill-react-vite-tailwind/src/components/app-explorer-link.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/app-explorer-link.tsx
@@ -1,5 +1,5 @@
 import { getExplorerLink, GetExplorerLinkArgs } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function AppExplorerLink({
   className,
@@ -9,7 +9,7 @@ export function AppExplorerLink({
   className?: string
   label: string
 }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   return (
     <a
       href={getExplorerLink({ ...link, cluster: cluster.cluster })}

--- a/gill/gill-react-vite-tailwind/src/components/solana/use-solana.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/solana/use-solana.tsx
@@ -1,0 +1,14 @@
+import { useWalletUi } from '@wallet-ui/react'
+
+/**
+ * Custom hook to abstract Wallet UI and related functionality from your app.
+ *
+ * This is a great place to add custom shared Solana logic or clients.
+ */
+export function useSolana() {
+  const walletUi = useWalletUi()
+
+  return {
+    ...walletUi,
+  }
+}

--- a/gill/gill-react-vite-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/solana/use-wallet-transaction-sign-and-send.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
 import type { Instruction, TransactionSendingSigner } from 'gill'
 import { createTransaction, getBase58Decoder, signAndSendTransactionMessageWithSigners } from 'gill'
+import { useSolana } from './use-solana'
 
 export function useWalletTransactionSignAndSend() {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return async (ix: Instruction | Instruction[], signer: TransactionSendingSigner) => {
     const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send()

--- a/gill/gill-react-vite-tailwind/src/components/solana/use-wallet-ui-signer.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/solana/use-wallet-ui-signer.tsx
@@ -1,7 +1,8 @@
-import { UiWalletAccount, useWalletAccountTransactionSendingSigner, useWalletUi } from '@wallet-ui/react'
+import { UiWalletAccount, useWalletAccountTransactionSendingSigner } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useWalletUiSigner() {
-  const { account, cluster } = useWalletUi()
+  const { account, cluster } = useSolana()
 
   return useWalletAccountTransactionSendingSigner(account as UiWalletAccount, cluster.id)
 }

--- a/gill/gill-react-vite-tailwind/src/components/use-transaction-toast.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/use-transaction-toast.tsx
@@ -1,5 +1,5 @@
 import { toast } from 'sonner'
-import { AppExplorerLink } from '@/components/app-explorer-link.tsx'
+import { AppExplorerLink } from './app-explorer-link.tsx'
 
 export function useTransactionToast() {
   return (signature: string) => {

--- a/gill/gill-react-vite-tailwind/src/features/account/account-feature-index.tsx
+++ b/gill/gill-react-vite-tailwind/src/features/account/account-feature-index.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { WalletButton } from '@/components/solana/solana-provider'
 import { Navigate } from 'react-router'
 
 export default function AccountFeatureIndex() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
 
   if (account) {
     return <Navigate to={`/account/${account.address.toString()}`} replace />

--- a/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-balance-query-key.ts
+++ b/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-balance-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetBalanceQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-balance', { cluster, address }]
 }

--- a/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-balance-query.ts
+++ b/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-balance-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetBalanceQueryKey } from './use-get-balance-query-key'
 
 export function useGetBalanceQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     retry: false,

--- a/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-signatures-query-key.ts
+++ b/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-signatures-query-key.ts
@@ -1,8 +1,8 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 
 export function useGetSignaturesQueryKey({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return ['get-signatures', { cluster, address }]
 }

--- a/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-signatures-query.ts
+++ b/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-signatures-query.ts
@@ -1,10 +1,10 @@
 import type { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useGetSignaturesQueryKey } from './use-get-signatures-query-key'
 
 export function useGetSignaturesQuery({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
 
   return useQuery({
     queryKey: useGetSignaturesQueryKey({ address }),

--- a/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-token-accounts-query.ts
+++ b/gill/gill-react-vite-tailwind/src/features/account/data-access/use-get-token-accounts-query.ts
@@ -1,11 +1,11 @@
 import type { Address } from 'gill'
 import { TOKEN_2022_PROGRAM_ADDRESS, TOKEN_PROGRAM_ADDRESS } from 'gill/programs/token'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { getTokenAccountsByOwner } from './get-token-accounts-by-owner'
 
 export function useGetTokenAccountsQuery({ address }: { address: Address }) {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-token-accounts', { cluster, address }],

--- a/gill/gill-react-vite-tailwind/src/features/account/data-access/use-request-airdrop-mutation.ts
+++ b/gill/gill-react-vite-tailwind/src/features/account/data-access/use-request-airdrop-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { type Address, airdropFactory, lamports } from 'gill'
 import { toastTx } from '@/components/toast-tx'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useRequestAirdropMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })
   const airdrop = airdropFactory(client)

--- a/gill/gill-react-vite-tailwind/src/features/account/data-access/use-transfer-sol-mutation.ts
+++ b/gill/gill-react-vite-tailwind/src/features/account/data-access/use-transfer-sol-mutation.ts
@@ -2,14 +2,14 @@ import { Address, createTransaction, getBase58Decoder, signAndSendTransactionMes
 import { getTransferSolInstruction } from 'gill/programs'
 import { toast } from 'sonner'
 import { useMutation } from '@tanstack/react-query'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { toastTx } from '@/components/toast-tx'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
 import { useInvalidateGetBalanceQuery } from './use-invalidate-get-balance-query'
 import { useInvalidateGetSignaturesQuery } from './use-invalidate-get-signatures-query'
 
 export function useTransferSolMutation({ address }: { address: Address }) {
-  const { client } = useWalletUi()
+  const { client } = useSolana()
   const signer = useWalletUiSigner()
   const invalidateBalanceQuery = useInvalidateGetBalanceQuery({ address })
   const invalidateSignaturesQuery = useInvalidateGetSignaturesQuery({ address })

--- a/gill/gill-react-vite-tailwind/src/features/account/ui/account-ui-balance-check.tsx
+++ b/gill/gill-react-vite-tailwind/src/features/account/ui/account-ui-balance-check.tsx
@@ -1,12 +1,12 @@
 import { Address } from 'gill'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AppAlert } from '@/components/app-alert'
 import { Button } from '@/components/ui/button'
 import { useRequestAirdropMutation } from '../data-access/use-request-airdrop-mutation'
 import { useGetBalanceQuery } from '../data-access/use-get-balance-query'
 
 export function AccountUiBalanceCheck({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const mutation = useRequestAirdropMutation({ address })
   const query = useGetBalanceQuery({ address })
 

--- a/gill/gill-react-vite-tailwind/src/features/account/ui/account-ui-buttons.tsx
+++ b/gill/gill-react-vite-tailwind/src/features/account/ui/account-ui-buttons.tsx
@@ -1,13 +1,13 @@
 import { Address } from 'gill'
 
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { AccountUiModalAirdrop } from './account-ui-modal-airdrop'
 import { AccountUiModalReceive } from './account-ui-modal-receive'
 import { AccountUiModalSend } from './account-ui-modal-send'
 import { ErrorBoundary } from 'react-error-boundary'
 
 export function AccountUiButtons({ address }: { address: Address }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
 
   return (
     <div>

--- a/gill/gill-react-vite-tailwind/src/features/account/ui/account-ui-checker.tsx
+++ b/gill/gill-react-vite-tailwind/src/features/account/ui/account-ui-checker.tsx
@@ -1,9 +1,9 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { address } from 'gill'
 import { AccountUiBalanceCheck } from './account-ui-balance-check'
 
 export function AccountUiChecker() {
-  const { account } = useWalletUi()
+  const { account } = useSolana()
   if (!account) {
     return null
   }

--- a/gill/gill-react-vite-tailwind/src/features/cluster/data-access/use-cluster-version.ts
+++ b/gill/gill-react-vite-tailwind/src/features/cluster/data-access/use-cluster-version.ts
@@ -1,8 +1,8 @@
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 
 export function useClusterVersion() {
-  const { client, cluster } = useWalletUi()
+  const { client, cluster } = useSolana()
   return useQuery({
     retry: false,
     queryKey: ['version', { cluster }],

--- a/gill/gill-react-vite-tailwind/src/features/cluster/ui/cluster-ui-checker.tsx
+++ b/gill/gill-react-vite-tailwind/src/features/cluster/ui/cluster-ui-checker.tsx
@@ -1,11 +1,11 @@
 import { ReactNode } from 'react'
 import { Button } from '@/components/ui/button'
 import { AppAlert } from '@/components/app-alert'
-import { useWalletUi } from '@wallet-ui/react'
+import { useSolana } from '@/components/solana/use-solana'
 import { useClusterVersion } from '../data-access/use-cluster-version'
 
 export function ClusterUiChecker({ children }: { children: ReactNode }) {
-  const { cluster } = useWalletUi()
+  const { cluster } = useSolana()
   const query = useClusterVersion()
 
   if (query.isLoading) {


### PR DESCRIPTION
This PR adds a `useSolana` hook that wraps `useWalletUi`. 

In general it's a good practice to wrap around 3rd party libs and with the next major release of Wallet UI where `gill` is separated out into the `@wallet-ui/react-gill` package, this is the spot where we will merge the 2. 

That way, the developer doesn't need to know or care where the `client` comes from.