### PR TITLE
feat: make dashboards look prettier

### DIFF
--- a/gill/gill-next-tailwind-basic/src/components/ui/card.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/ui/card.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn('bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }

--- a/gill/gill-next-tailwind-basic/src/features/dashboard/dashboard-feature.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/dashboard/dashboard-feature.tsx
@@ -1,32 +1,118 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  ArrowRight,
+  BookOpen,
+  CookingPot,
+  Droplets,
+  LucideAnchor,
+  LucideCode,
+  LucideWallet,
+  MessageCircleQuestion,
+} from 'lucide-react'
+import React from 'react'
 import { AppHero } from '@/components/app-hero'
 
-const links: { label: string; href: string }[] = [
-  { label: 'Solana Docs', href: 'https://docs.solana.com/' },
-  { label: 'Solana Faucet', href: 'https://faucet.solana.com/' },
-  { label: 'Solana Cookbook', href: 'https://solana.com/developers/cookbook/' },
-  { label: 'Solana Stack Overflow', href: 'https://solana.stackexchange.com/' },
-  { label: 'Solana Developers GitHub', href: 'https://github.com/solana-developers/' },
+const primary: {
+  label: string
+  href: string
+  description: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Docs',
+    href: 'https://solana.com/docs',
+    description: 'The official documentation. Your first stop for understanding the Solana ecosystem.',
+    icon: <BookOpen className="w-8 h-8 text-purple-400" />,
+  },
+  {
+    label: 'Solana Cookbook',
+    href: 'https://solana.com/developers/cookbook/',
+    description: 'Practical examples and code snippets for common tasks when building on Solana.',
+    icon: <CookingPot className="w-8 h-8 text-green-400" />,
+  },
+]
+
+const secondary: {
+  label: string
+  href: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Faucet',
+    href: 'https://faucet.solana.com/',
+    icon: <Droplets className="w-5 h-5 text-green-400" />,
+  },
+  {
+    label: 'Solana Stack Overflow',
+    href: 'https://solana.stackexchange.com/',
+    icon: <MessageCircleQuestion className="w-5 h-5 text-orange-400" />,
+  },
+  {
+    label: 'Wallet UI Docs',
+    href: 'https://wallet-ui.dev',
+    icon: <LucideWallet className="w-5 h-5 text-blue-400" />,
+  },
+  {
+    label: 'Anchor Docs',
+    href: 'https://www.anchor-lang.com/docs',
+    icon: <LucideAnchor className="w-5 h-5 text-indigo-400" />,
+  },
+  {
+    label: 'Codama Repository',
+    href: 'https://github.com/codama-idl/codama',
+    icon: <LucideCode className="w-5 h-5 text-lime-400" />,
+  },
 ]
 
 export default function DashboardFeature() {
   return (
     <div>
       <AppHero title="gm" subtitle="Say hi to your new Solana app." />
-      <div className="max-w-xl mx-auto py-6 sm:px-6 lg:px-8 text-center">
-        <div className="space-y-2">
-          <p>Here are some helpful links to get you started.</p>
-          {links.map((link, index) => (
-            <div key={index}>
-              <a
-                href={link.href}
-                className="hover:text-gray-500 dark:hover:text-gray-300"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {link.label}
-              </a>
-            </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {primary.map((link) => (
+            <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="block group">
+              <Card className="h-full flex flex-col transition-all duration-200 ease-in-out group-hover:border-primary group-hover:shadow-lg group-hover:-translate-y-1">
+                <CardHeader className="flex-row items-center gap-4">
+                  {link.icon}
+                  <div>
+                    <CardTitle className="group-hover:text-primary transition-colors">{link.label}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <p className="text-muted-foreground">{link.description}</p>
+                </CardContent>
+              </Card>
+            </a>
           ))}
+        </div>
+        <div className="mt-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>More Resources</CardTitle>
+              <CardDescription>Expand your knowledge with these community and support links.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4">
+                {secondary.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="flex items-center gap-4 group rounded-md p-2 -m-2 hover:bg-muted transition-colors"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {link.icon}
+                      <span className="flex-grow text-muted-foreground group-hover:text-foreground transition-colors">
+                        {link.label}
+                      </span>
+                      <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/gill/gill-next-tailwind-counter/src/features/dashboard/dashboard-feature.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/dashboard/dashboard-feature.tsx
@@ -1,32 +1,118 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  ArrowRight,
+  BookOpen,
+  CookingPot,
+  Droplets,
+  LucideAnchor,
+  LucideCode,
+  LucideWallet,
+  MessageCircleQuestion,
+} from 'lucide-react'
+import React from 'react'
 import { AppHero } from '@/components/app-hero'
 
-const links: { label: string; href: string }[] = [
-  { label: 'Solana Docs', href: 'https://docs.solana.com/' },
-  { label: 'Solana Faucet', href: 'https://faucet.solana.com/' },
-  { label: 'Solana Cookbook', href: 'https://solana.com/developers/cookbook/' },
-  { label: 'Solana Stack Overflow', href: 'https://solana.stackexchange.com/' },
-  { label: 'Solana Developers GitHub', href: 'https://github.com/solana-developers/' },
+const primary: {
+  label: string
+  href: string
+  description: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Docs',
+    href: 'https://solana.com/docs',
+    description: 'The official documentation. Your first stop for understanding the Solana ecosystem.',
+    icon: <BookOpen className="w-8 h-8 text-purple-400" />,
+  },
+  {
+    label: 'Solana Cookbook',
+    href: 'https://solana.com/developers/cookbook/',
+    description: 'Practical examples and code snippets for common tasks when building on Solana.',
+    icon: <CookingPot className="w-8 h-8 text-green-400" />,
+  },
+]
+
+const secondary: {
+  label: string
+  href: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Faucet',
+    href: 'https://faucet.solana.com/',
+    icon: <Droplets className="w-5 h-5 text-green-400" />,
+  },
+  {
+    label: 'Solana Stack Overflow',
+    href: 'https://solana.stackexchange.com/',
+    icon: <MessageCircleQuestion className="w-5 h-5 text-orange-400" />,
+  },
+  {
+    label: 'Wallet UI Docs',
+    href: 'https://wallet-ui.dev',
+    icon: <LucideWallet className="w-5 h-5 text-blue-400" />,
+  },
+  {
+    label: 'Anchor Docs',
+    href: 'https://www.anchor-lang.com/docs',
+    icon: <LucideAnchor className="w-5 h-5 text-indigo-400" />,
+  },
+  {
+    label: 'Codama Repository',
+    href: 'https://github.com/codama-idl/codama',
+    icon: <LucideCode className="w-5 h-5 text-lime-400" />,
+  },
 ]
 
 export default function DashboardFeature() {
   return (
     <div>
       <AppHero title="gm" subtitle="Say hi to your new Solana app." />
-      <div className="max-w-xl mx-auto py-6 sm:px-6 lg:px-8 text-center">
-        <div className="space-y-2">
-          <p>Here are some helpful links to get you started.</p>
-          {links.map((link, index) => (
-            <div key={index}>
-              <a
-                href={link.href}
-                className="hover:text-gray-500 dark:hover:text-gray-300"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {link.label}
-              </a>
-            </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {primary.map((link) => (
+            <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="block group">
+              <Card className="h-full flex flex-col transition-all duration-200 ease-in-out group-hover:border-primary group-hover:shadow-lg group-hover:-translate-y-1">
+                <CardHeader className="flex-row items-center gap-4">
+                  {link.icon}
+                  <div>
+                    <CardTitle className="group-hover:text-primary transition-colors">{link.label}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <p className="text-muted-foreground">{link.description}</p>
+                </CardContent>
+              </Card>
+            </a>
           ))}
+        </div>
+        <div className="mt-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>More Resources</CardTitle>
+              <CardDescription>Expand your knowledge with these community and support links.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4">
+                {secondary.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="flex items-center gap-4 group rounded-md p-2 -m-2 hover:bg-muted transition-colors"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {link.icon}
+                      <span className="flex-grow text-muted-foreground group-hover:text-foreground transition-colors">
+                        {link.label}
+                      </span>
+                      <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/gill/gill-next-tailwind/src/components/ui/card.tsx
+++ b/gill/gill-next-tailwind/src/components/ui/card.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn('bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }

--- a/gill/gill-next-tailwind/src/features/dashboard/dashboard-feature.tsx
+++ b/gill/gill-next-tailwind/src/features/dashboard/dashboard-feature.tsx
@@ -1,32 +1,99 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { ArrowRight, BookOpen, CookingPot, Droplets, LucideWallet, MessageCircleQuestion } from 'lucide-react'
+import React from 'react'
 import { AppHero } from '@/components/app-hero'
 
-const links: { label: string; href: string }[] = [
-  { label: 'Solana Docs', href: 'https://docs.solana.com/' },
-  { label: 'Solana Faucet', href: 'https://faucet.solana.com/' },
-  { label: 'Solana Cookbook', href: 'https://solana.com/developers/cookbook/' },
-  { label: 'Solana Stack Overflow', href: 'https://solana.stackexchange.com/' },
-  { label: 'Solana Developers GitHub', href: 'https://github.com/solana-developers/' },
+const primary: {
+  label: string
+  href: string
+  description: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Docs',
+    href: 'https://solana.com/docs',
+    description: 'The official documentation. Your first stop for understanding the Solana ecosystem.',
+    icon: <BookOpen className="w-8 h-8 text-purple-400" />,
+  },
+  {
+    label: 'Solana Cookbook',
+    href: 'https://solana.com/developers/cookbook/',
+    description: 'Practical examples and code snippets for common tasks when building on Solana.',
+    icon: <CookingPot className="w-8 h-8 text-green-400" />,
+  },
+]
+
+const secondary: {
+  label: string
+  href: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Faucet',
+    href: 'https://faucet.solana.com/',
+    icon: <Droplets className="w-5 h-5 text-green-400" />,
+  },
+  {
+    label: 'Solana Stack Overflow',
+    href: 'https://solana.stackexchange.com/',
+    icon: <MessageCircleQuestion className="w-5 h-5 text-orange-400" />,
+  },
+  {
+    label: 'Wallet UI Docs',
+    href: 'https://wallet-ui.dev',
+    icon: <LucideWallet className="w-5 h-5 text-blue-400" />,
+  },
 ]
 
 export default function DashboardFeature() {
   return (
     <div>
       <AppHero title="gm" subtitle="Say hi to your new Solana app." />
-      <div className="max-w-xl mx-auto py-6 sm:px-6 lg:px-8 text-center">
-        <div className="space-y-2">
-          <p>Here are some helpful links to get you started.</p>
-          {links.map((link, index) => (
-            <div key={index}>
-              <a
-                href={link.href}
-                className="hover:text-gray-500 dark:hover:text-gray-300"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {link.label}
-              </a>
-            </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {primary.map((link) => (
+            <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="block group">
+              <Card className="h-full flex flex-col transition-all duration-200 ease-in-out group-hover:border-primary group-hover:shadow-lg group-hover:-translate-y-1">
+                <CardHeader className="flex-row items-center gap-4">
+                  {link.icon}
+                  <div>
+                    <CardTitle className="group-hover:text-primary transition-colors">{link.label}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <p className="text-muted-foreground">{link.description}</p>
+                </CardContent>
+              </Card>
+            </a>
           ))}
+        </div>
+        <div className="mt-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>More Resources</CardTitle>
+              <CardDescription>Expand your knowledge with these community and support links.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4">
+                {secondary.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="flex items-center gap-4 group rounded-md p-2 -m-2 hover:bg-muted transition-colors"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {link.icon}
+                      <span className="flex-grow text-muted-foreground group-hover:text-foreground transition-colors">
+                        {link.label}
+                      </span>
+                      <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/gill/gill-react-vite-tailwind-basic/src/features/dashboard/dashboard-feature.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/dashboard/dashboard-feature.tsx
@@ -1,32 +1,118 @@
-import { AppHero } from '@/components/app-hero'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  ArrowRight,
+  BookOpen,
+  CookingPot,
+  Droplets,
+  LucideAnchor,
+  LucideCode,
+  LucideWallet,
+  MessageCircleQuestion,
+} from 'lucide-react'
+import React from 'react'
+import { AppHero } from '@/components/app-hero.tsx'
 
-const links: { label: string; href: string }[] = [
-  { label: 'Solana Docs', href: 'https://docs.solana.com/' },
-  { label: 'Solana Faucet', href: 'https://faucet.solana.com/' },
-  { label: 'Solana Cookbook', href: 'https://solana.com/developers/cookbook/' },
-  { label: 'Solana Stack Overflow', href: 'https://solana.stackexchange.com/' },
-  { label: 'Solana Developers GitHub', href: 'https://github.com/solana-developers/' },
+const primary: {
+  label: string
+  href: string
+  description: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Docs',
+    href: 'https://solana.com/docs',
+    description: 'The official documentation. Your first stop for understanding the Solana ecosystem.',
+    icon: <BookOpen className="w-8 h-8 text-purple-400" />,
+  },
+  {
+    label: 'Solana Cookbook',
+    href: 'https://solana.com/developers/cookbook/',
+    description: 'Practical examples and code snippets for common tasks when building on Solana.',
+    icon: <CookingPot className="w-8 h-8 text-green-400" />,
+  },
+]
+
+const secondary: {
+  label: string
+  href: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Faucet',
+    href: 'https://faucet.solana.com/',
+    icon: <Droplets className="w-5 h-5 text-green-400" />,
+  },
+  {
+    label: 'Solana Stack Overflow',
+    href: 'https://solana.stackexchange.com/',
+    icon: <MessageCircleQuestion className="w-5 h-5 text-orange-400" />,
+  },
+  {
+    label: 'Wallet UI Docs',
+    href: 'https://wallet-ui.dev',
+    icon: <LucideWallet className="w-5 h-5 text-blue-400" />,
+  },
+  {
+    label: 'Anchor Docs',
+    href: 'https://www.anchor-lang.com/docs',
+    icon: <LucideAnchor className="w-5 h-5 text-indigo-400" />,
+  },
+  {
+    label: 'Codama Repository',
+    href: 'https://github.com/codama-idl/codama',
+    icon: <LucideCode className="w-5 h-5 text-lime-400" />,
+  },
 ]
 
 export default function DashboardFeature() {
   return (
     <div>
       <AppHero title="gm" subtitle="Say hi to your new Solana app." />
-      <div className="max-w-xl mx-auto py-6 sm:px-6 lg:px-8 text-center">
-        <div className="space-y-2">
-          <p>Here are some helpful links to get you started.</p>
-          {links.map((link, index) => (
-            <div key={index}>
-              <a
-                href={link.href}
-                className="hover:text-gray-500 dark:hover:text-gray-300"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {link.label}
-              </a>
-            </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {primary.map((link) => (
+            <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="block group">
+              <Card className="h-full flex flex-col transition-all duration-200 ease-in-out group-hover:border-primary group-hover:shadow-lg group-hover:-translate-y-1">
+                <CardHeader className="flex-row items-center gap-4">
+                  {link.icon}
+                  <div>
+                    <CardTitle className="group-hover:text-primary transition-colors">{link.label}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <p className="text-muted-foreground">{link.description}</p>
+                </CardContent>
+              </Card>
+            </a>
           ))}
+        </div>
+        <div className="mt-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>More Resources</CardTitle>
+              <CardDescription>Expand your knowledge with these community and support links.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4">
+                {secondary.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="flex items-center gap-4 group rounded-md p-2 -m-2 hover:bg-muted transition-colors"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {link.icon}
+                      <span className="flex-grow text-muted-foreground group-hover:text-foreground transition-colors">
+                        {link.label}
+                      </span>
+                      <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/gill/gill-react-vite-tailwind-counter/src/features/dashboard/dashboard-feature.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/dashboard/dashboard-feature.tsx
@@ -1,32 +1,118 @@
-import { AppHero } from '@/components/app-hero'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  ArrowRight,
+  BookOpen,
+  CookingPot,
+  Droplets,
+  LucideAnchor,
+  LucideCode,
+  LucideWallet,
+  MessageCircleQuestion,
+} from 'lucide-react'
+import React from 'react'
+import { AppHero } from '@/components/app-hero.tsx'
 
-const links: { label: string; href: string }[] = [
-  { label: 'Solana Docs', href: 'https://docs.solana.com/' },
-  { label: 'Solana Faucet', href: 'https://faucet.solana.com/' },
-  { label: 'Solana Cookbook', href: 'https://solana.com/developers/cookbook/' },
-  { label: 'Solana Stack Overflow', href: 'https://solana.stackexchange.com/' },
-  { label: 'Solana Developers GitHub', href: 'https://github.com/solana-developers/' },
+const primary: {
+  label: string
+  href: string
+  description: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Docs',
+    href: 'https://solana.com/docs',
+    description: 'The official documentation. Your first stop for understanding the Solana ecosystem.',
+    icon: <BookOpen className="w-8 h-8 text-purple-400" />,
+  },
+  {
+    label: 'Solana Cookbook',
+    href: 'https://solana.com/developers/cookbook/',
+    description: 'Practical examples and code snippets for common tasks when building on Solana.',
+    icon: <CookingPot className="w-8 h-8 text-green-400" />,
+  },
+]
+
+const secondary: {
+  label: string
+  href: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Faucet',
+    href: 'https://faucet.solana.com/',
+    icon: <Droplets className="w-5 h-5 text-green-400" />,
+  },
+  {
+    label: 'Solana Stack Overflow',
+    href: 'https://solana.stackexchange.com/',
+    icon: <MessageCircleQuestion className="w-5 h-5 text-orange-400" />,
+  },
+  {
+    label: 'Wallet UI Docs',
+    href: 'https://wallet-ui.dev',
+    icon: <LucideWallet className="w-5 h-5 text-blue-400" />,
+  },
+  {
+    label: 'Anchor Docs',
+    href: 'https://www.anchor-lang.com/docs',
+    icon: <LucideAnchor className="w-5 h-5 text-indigo-400" />,
+  },
+  {
+    label: 'Codama Repository',
+    href: 'https://github.com/codama-idl/codama',
+    icon: <LucideCode className="w-5 h-5 text-lime-400" />,
+  },
 ]
 
 export default function DashboardFeature() {
   return (
     <div>
       <AppHero title="gm" subtitle="Say hi to your new Solana app." />
-      <div className="max-w-xl mx-auto py-6 sm:px-6 lg:px-8 text-center">
-        <div className="space-y-2">
-          <p>Here are some helpful links to get you started.</p>
-          {links.map((link, index) => (
-            <div key={index}>
-              <a
-                href={link.href}
-                className="hover:text-gray-500 dark:hover:text-gray-300"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {link.label}
-              </a>
-            </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {primary.map((link) => (
+            <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="block group">
+              <Card className="h-full flex flex-col transition-all duration-200 ease-in-out group-hover:border-primary group-hover:shadow-lg group-hover:-translate-y-1">
+                <CardHeader className="flex-row items-center gap-4">
+                  {link.icon}
+                  <div>
+                    <CardTitle className="group-hover:text-primary transition-colors">{link.label}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <p className="text-muted-foreground">{link.description}</p>
+                </CardContent>
+              </Card>
+            </a>
           ))}
+        </div>
+        <div className="mt-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>More Resources</CardTitle>
+              <CardDescription>Expand your knowledge with these community and support links.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4">
+                {secondary.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="flex items-center gap-4 group rounded-md p-2 -m-2 hover:bg-muted transition-colors"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {link.icon}
+                      <span className="flex-grow text-muted-foreground group-hover:text-foreground transition-colors">
+                        {link.label}
+                      </span>
+                      <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>

--- a/gill/gill-react-vite-tailwind/src/components/ui/card.tsx
+++ b/gill/gill-react-vite-tailwind/src/components/ui/card.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn('bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm', className)}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent }

--- a/gill/gill-react-vite-tailwind/src/features/dashboard/dashboard-feature.tsx
+++ b/gill/gill-react-vite-tailwind/src/features/dashboard/dashboard-feature.tsx
@@ -1,32 +1,99 @@
-import { AppHero } from '@/components/app-hero'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { ArrowRight, BookOpen, CookingPot, Droplets, LucideWallet, MessageCircleQuestion } from 'lucide-react'
+import React from 'react'
+import { AppHero } from '@/components/app-hero.tsx'
 
-const links: { label: string; href: string }[] = [
-  { label: 'Solana Docs', href: 'https://docs.solana.com/' },
-  { label: 'Solana Faucet', href: 'https://faucet.solana.com/' },
-  { label: 'Solana Cookbook', href: 'https://solana.com/developers/cookbook/' },
-  { label: 'Solana Stack Overflow', href: 'https://solana.stackexchange.com/' },
-  { label: 'Solana Developers GitHub', href: 'https://github.com/solana-developers/' },
+const primary: {
+  label: string
+  href: string
+  description: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Docs',
+    href: 'https://solana.com/docs',
+    description: 'The official documentation. Your first stop for understanding the Solana ecosystem.',
+    icon: <BookOpen className="w-8 h-8 text-purple-400" />,
+  },
+  {
+    label: 'Solana Cookbook',
+    href: 'https://solana.com/developers/cookbook/',
+    description: 'Practical examples and code snippets for common tasks when building on Solana.',
+    icon: <CookingPot className="w-8 h-8 text-green-400" />,
+  },
+]
+
+const secondary: {
+  label: string
+  href: string
+  icon: React.ReactNode
+}[] = [
+  {
+    label: 'Solana Faucet',
+    href: 'https://faucet.solana.com/',
+    icon: <Droplets className="w-5 h-5 text-green-400" />,
+  },
+  {
+    label: 'Solana Stack Overflow',
+    href: 'https://solana.stackexchange.com/',
+    icon: <MessageCircleQuestion className="w-5 h-5 text-orange-400" />,
+  },
+  {
+    label: 'Wallet UI Docs',
+    href: 'https://wallet-ui.dev',
+    icon: <LucideWallet className="w-5 h-5 text-blue-400" />,
+  },
 ]
 
 export default function DashboardFeature() {
   return (
     <div>
       <AppHero title="gm" subtitle="Say hi to your new Solana app." />
-      <div className="max-w-xl mx-auto py-6 sm:px-6 lg:px-8 text-center">
-        <div className="space-y-2">
-          <p>Here are some helpful links to get you started.</p>
-          {links.map((link, index) => (
-            <div key={index}>
-              <a
-                href={link.href}
-                className="hover:text-gray-500 dark:hover:text-gray-300"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {link.label}
-              </a>
-            </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {primary.map((link) => (
+            <a key={link.label} href={link.href} target="_blank" rel="noopener noreferrer" className="block group">
+              <Card className="h-full flex flex-col transition-all duration-200 ease-in-out group-hover:border-primary group-hover:shadow-lg group-hover:-translate-y-1">
+                <CardHeader className="flex-row items-center gap-4">
+                  {link.icon}
+                  <div>
+                    <CardTitle className="group-hover:text-primary transition-colors">{link.label}</CardTitle>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  <p className="text-muted-foreground">{link.description}</p>
+                </CardContent>
+              </Card>
+            </a>
           ))}
+        </div>
+        <div className="mt-8">
+          <Card>
+            <CardHeader>
+              <CardTitle>More Resources</CardTitle>
+              <CardDescription>Expand your knowledge with these community and support links.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4">
+                {secondary.map((link) => (
+                  <li key={link.label}>
+                    <a
+                      href={link.href}
+                      className="flex items-center gap-4 group rounded-md p-2 -m-2 hover:bg-muted transition-colors"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {link.icon}
+                      <span className="flex-grow text-muted-foreground group-hover:text-foreground transition-colors">
+                        {link.label}
+                      </span>
+                      <ArrowRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This patch gives some polish to the dashboard of the all the modern gill-based templates. 

The templates that include an Anchor example link to the Anchor and Codama docs, the others don't have that. 

Before:
<img width="1598" height="1109" alt="image" src="https://github.com/user-attachments/assets/cbe85286-3b7d-4d5d-9dd1-65acdd0c10a0" />

After:
<img width="1214" height="1141" alt="image" src="https://github.com/user-attachments/assets/4b642c04-0de6-48ce-bbcc-ba02bea5c25f" />
<img width="1214" height="1141" alt="image" src="https://github.com/user-attachments/assets/59dd0f56-caa7-4934-aeb4-08fdb9a0a734" />
