### PR TITLE
fix: remove `solanaMobileWalletAdapter` warning when window is undefined

### DIFF
--- a/gill/gill-next-tailwind-basic/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-next-tailwind-basic/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -16,7 +16,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {

--- a/gill/gill-next-tailwind-counter/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-next-tailwind-counter/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -16,7 +16,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {

--- a/gill/gill-next-tailwind-minimal/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-next-tailwind-minimal/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -16,7 +16,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {

--- a/gill/gill-next-tailwind/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-next-tailwind/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -16,7 +16,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {

--- a/gill/gill-react-vite-tailwind-basic/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -14,7 +14,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {

--- a/gill/gill-react-vite-tailwind-counter/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -14,7 +14,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {

--- a/gill/gill-react-vite-tailwind-minimal/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-react-vite-tailwind-minimal/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -14,7 +14,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {

--- a/gill/gill-react-vite-tailwind/src/components/solana/solana-mobile-wallet-adapter.ts
+++ b/gill/gill-react-vite-tailwind/src/components/solana/solana-mobile-wallet-adapter.ts
@@ -14,7 +14,6 @@ export function solanaMobileWalletAdapter({
   clusters: SolanaCluster[]
 }) {
   if (typeof window === 'undefined') {
-    console.warn(`Solana Mobile Wallet Adapter not loaded: no window object`)
     return
   }
   if (!window.isSecureContext) {


### PR DESCRIPTION
Removing this warning as it ends up cluttering the console when running a dev server and the server logs when hosted.

<img width="500" height="104" alt="image" src="https://github.com/user-attachments/assets/6f7f2055-bb7f-49ea-a750-fcd07cae311d" />
