### PR TITLE
chore: update program id of counter example on devnet/testnet

### DIFF
--- a/gill/gill-next-tailwind-counter/anchor/Anchor.toml
+++ b/gill/gill-next-tailwind-counter/anchor/Anchor.toml
@@ -6,7 +6,7 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-counter = "JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H"
+counter = "Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe"
 
 [registry]
 url = "https://api.apr.dev"

--- a/gill/gill-next-tailwind-counter/anchor/programs/counter/src/lib.rs
+++ b/gill/gill-next-tailwind-counter/anchor/programs/counter/src/lib.rs
@@ -2,7 +2,7 @@
 
 use anchor_lang::prelude::*;
 
-declare_id!("JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H");
+declare_id!("Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe");
 
 #[program]
 pub mod counter {

--- a/gill/gill-next-tailwind-counter/anchor/src/client/js/generated/programs/counter.ts
+++ b/gill/gill-next-tailwind-counter/anchor/src/client/js/generated/programs/counter.ts
@@ -22,7 +22,7 @@ import {
 } from '../instructions';
 
 export const COUNTER_PROGRAM_ADDRESS =
-  'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H' as Address<'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H'>;
+  'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe' as Address<'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe'>;
 
 export enum CounterAccount {
   Counter,
@@ -121,7 +121,7 @@ export function identifyCounterInstruction(
 }
 
 export type ParsedCounterInstruction<
-  TProgram extends string = 'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H',
+  TProgram extends string = 'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe',
 > =
   | ({
       instructionType: CounterInstruction.Close;

--- a/gill/gill-next-tailwind-counter/anchor/src/counter-exports.ts
+++ b/gill/gill-next-tailwind-counter/anchor/src/counter-exports.ts
@@ -16,7 +16,7 @@ export function getCounterProgramId(cluster: SolanaClusterId) {
     case 'solana:devnet':
     case 'solana:testnet':
       // This is the program ID for the Counter program on devnet and testnet.
-      return address('6z68wfurCMYkZG51s1Et9BJEd9nJGUusjHXNt4dGbNNF')
+      return address('Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe')
     case 'solana:mainnet':
     default:
       return COUNTER_PROGRAM_ADDRESS

--- a/gill/gill-next-tailwind-counter/anchor/target/idl/counter.json
+++ b/gill/gill-next-tailwind-counter/anchor/target/idl/counter.json
@@ -1,5 +1,5 @@
 {
-  "address": "JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H",
+  "address": "Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe",
   "metadata": {
     "name": "counter",
     "version": "0.1.0",

--- a/gill/gill-next-tailwind-counter/anchor/target/types/counter.ts
+++ b/gill/gill-next-tailwind-counter/anchor/target/types/counter.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/counter.json`.
  */
 export type Counter = {
-  address: 'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H'
+  address: 'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe'
   metadata: {
     name: 'counter'
     version: '0.1.0'

--- a/gill/gill-next-tailwind-counter/package.json
+++ b/gill/gill-next-tailwind-counter/package.json
@@ -49,7 +49,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "next lint",
-    "setup": "npm run anchor keys sync && npm run codama:js",
+    "setup": "npm run anchor keys sync && npm run anchor build && npm run codama:js",
     "start": "next start"
   },
   "dependencies": {

--- a/gill/gill-react-vite-tailwind-counter/anchor/Anchor.toml
+++ b/gill/gill-react-vite-tailwind-counter/anchor/Anchor.toml
@@ -6,7 +6,7 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-counter = "JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H"
+counter = "Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe"
 
 [registry]
 url = "https://api.apr.dev"

--- a/gill/gill-react-vite-tailwind-counter/anchor/programs/counter/src/lib.rs
+++ b/gill/gill-react-vite-tailwind-counter/anchor/programs/counter/src/lib.rs
@@ -2,7 +2,7 @@
 
 use anchor_lang::prelude::*;
 
-declare_id!("JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H");
+declare_id!("Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe");
 
 #[program]
 pub mod counter {

--- a/gill/gill-react-vite-tailwind-counter/anchor/src/client/js/generated/programs/counter.ts
+++ b/gill/gill-react-vite-tailwind-counter/anchor/src/client/js/generated/programs/counter.ts
@@ -22,7 +22,7 @@ import {
 } from '../instructions';
 
 export const COUNTER_PROGRAM_ADDRESS =
-  'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H' as Address<'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H'>;
+  'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe' as Address<'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe'>;
 
 export enum CounterAccount {
   Counter,
@@ -121,7 +121,7 @@ export function identifyCounterInstruction(
 }
 
 export type ParsedCounterInstruction<
-  TProgram extends string = 'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H',
+  TProgram extends string = 'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe',
 > =
   | ({
       instructionType: CounterInstruction.Close;

--- a/gill/gill-react-vite-tailwind-counter/anchor/target/idl/counter.json
+++ b/gill/gill-react-vite-tailwind-counter/anchor/target/idl/counter.json
@@ -1,5 +1,5 @@
 {
-  "address": "JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H",
+  "address": "Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe",
   "metadata": {
     "name": "counter",
     "version": "0.1.0",

--- a/gill/gill-react-vite-tailwind-counter/anchor/target/types/counter.ts
+++ b/gill/gill-react-vite-tailwind-counter/anchor/target/types/counter.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/counter.json`.
  */
 export type Counter = {
-  address: 'JAVuBXeBZqXNtS73azhBDAoYaaAFfo4gWXoZe2e7Jf8H'
+  address: 'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe'
   metadata: {
     name: 'counter'
     version: '0.1.0'

--- a/gill/gill-react-vite-tailwind-counter/package.json
+++ b/gill/gill-react-vite-tailwind-counter/package.json
@@ -49,7 +49,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint .",
     "preview": "vite preview",
-    "setup": "npm run anchor keys sync && npm run codama:js"
+    "setup": "npm run anchor keys sync && npm run anchor build && npm run codama:js"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",

--- a/web3js/web3js-next-tailwind-counter/anchor/Anchor.toml
+++ b/web3js/web3js-next-tailwind-counter/anchor/Anchor.toml
@@ -6,7 +6,7 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-counter = "FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS"
+counter = "Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe"
 
 [registry]
 url = "https://api.apr.dev"

--- a/web3js/web3js-next-tailwind-counter/anchor/programs/counter/src/lib.rs
+++ b/web3js/web3js-next-tailwind-counter/anchor/programs/counter/src/lib.rs
@@ -2,7 +2,7 @@
 
 use anchor_lang::prelude::*;
 
-declare_id!("FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS");
+declare_id!("Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe");
 
 #[program]
 pub mod counter {

--- a/web3js/web3js-next-tailwind-counter/anchor/src/counter-exports.ts
+++ b/web3js/web3js-next-tailwind-counter/anchor/src/counter-exports.ts
@@ -21,7 +21,7 @@ export function getCounterProgramId(cluster: Cluster) {
     case 'devnet':
     case 'testnet':
       // This is the program ID for the Counter program on devnet and testnet.
-      return new PublicKey('coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF')
+      return new PublicKey('Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe')
     case 'mainnet-beta':
     default:
       return COUNTER_PROGRAM_ID

--- a/web3js/web3js-next-tailwind-counter/anchor/target/idl/counter.json
+++ b/web3js/web3js-next-tailwind-counter/anchor/target/idl/counter.json
@@ -1,5 +1,5 @@
 {
-  "address": "FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS",
+  "address": "Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe",
   "metadata": {
     "name": "counter",
     "version": "0.1.0",

--- a/web3js/web3js-next-tailwind-counter/anchor/target/types/counter.ts
+++ b/web3js/web3js-next-tailwind-counter/anchor/target/types/counter.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/counter.json`.
  */
 export type Counter = {
-  address: 'FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS'
+  address: 'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe'
   metadata: {
     name: 'counter'
     version: '0.1.0'

--- a/web3js/web3js-react-vite-tailwind-counter/anchor/Anchor.toml
+++ b/web3js/web3js-react-vite-tailwind-counter/anchor/Anchor.toml
@@ -6,7 +6,7 @@ resolution = true
 skip-lint = false
 
 [programs.localnet]
-counter = "FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS"
+counter = "Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe"
 
 [registry]
 url = "https://api.apr.dev"

--- a/web3js/web3js-react-vite-tailwind-counter/anchor/programs/counter/src/lib.rs
+++ b/web3js/web3js-react-vite-tailwind-counter/anchor/programs/counter/src/lib.rs
@@ -2,7 +2,7 @@
 
 use anchor_lang::prelude::*;
 
-declare_id!("FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS");
+declare_id!("Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe");
 
 #[program]
 pub mod counter {

--- a/web3js/web3js-react-vite-tailwind-counter/anchor/src/counter-exports.ts
+++ b/web3js/web3js-react-vite-tailwind-counter/anchor/src/counter-exports.ts
@@ -21,7 +21,7 @@ export function getCounterProgramId(cluster: Cluster) {
     case 'devnet':
     case 'testnet':
       // This is the program ID for the Counter program on devnet and testnet.
-      return new PublicKey('coUnmi3oBUtwtd9fjeAvSsJssXh5A5xyPbhpewyzRVF')
+      return new PublicKey('Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe')
     case 'mainnet-beta':
     default:
       return COUNTER_PROGRAM_ID

--- a/web3js/web3js-react-vite-tailwind-counter/anchor/target/idl/counter.json
+++ b/web3js/web3js-react-vite-tailwind-counter/anchor/target/idl/counter.json
@@ -1,5 +1,5 @@
 {
-  "address": "FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS",
+  "address": "qCount3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe",
   "metadata": {
     "name": "counter",
     "version": "0.1.0",

--- a/web3js/web3js-react-vite-tailwind-counter/anchor/target/types/counter.ts
+++ b/web3js/web3js-react-vite-tailwind-counter/anchor/target/types/counter.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/counter.json`.
  */
 export type Counter = {
-  address: 'FqzkXZdwYjurnUKetJCAvaUw5WAqbwzU6gZEwydeEfqS'
+  address: 'Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe'
   metadata: {
     name: 'counter'
     version: '0.1.0'


### PR DESCRIPTION
The `programId` of the gill counter templates was set to an incorrect account.

I redeployed the program to `Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe` and updated the templates to point to this account on `devnet` and `testnet`.

Fixes #132 