### PR TITLE
fix: add versions property to init script for Anchor templates

### DIFF
--- a/gill/gill-next-tailwind-basic/package.json
+++ b/gill/gill-next-tailwind-basic/package.json
@@ -32,6 +32,10 @@
           "src"
         ]
       }
+    },
+    "versions": {
+      "anchor": "0.31.1",
+      "solana": "2.1.0"
     }
   },
   "version": "0.0.0",

--- a/gill/gill-next-tailwind-counter/package.json
+++ b/gill/gill-next-tailwind-counter/package.json
@@ -32,6 +32,10 @@
           "src"
         ]
       }
+    },
+    "versions": {
+      "anchor": "0.31.1",
+      "solana": "2.1.0"
     }
   },
   "version": "0.0.0",

--- a/gill/gill-react-vite-tailwind-basic/package.json
+++ b/gill/gill-react-vite-tailwind-basic/package.json
@@ -31,6 +31,10 @@
           "src"
         ]
       }
+    },
+    "versions": {
+      "anchor": "0.31.1",
+      "solana": "2.1.0"
     }
   },
   "version": "0.0.0",

--- a/gill/gill-react-vite-tailwind-counter/package.json
+++ b/gill/gill-react-vite-tailwind-counter/package.json
@@ -31,6 +31,10 @@
           "src"
         ]
       }
+    },
+    "versions": {
+      "anchor": "0.31.1",
+      "solana": "2.1.0"
     }
   },
   "version": "0.0.0",


### PR DESCRIPTION
This features was missing from these new templates and are now back.

<img width="1346" height="838" alt="image" src="https://github.com/user-attachments/assets/7ef82773-da79-4421-bb25-92c25c4fb9b0" />
