### PR TITLE
chore: set gh workflow permissions to 'contents: read'

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -10,6 +10,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   setup-templates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As per recommendation from CodeQL:

> Actions job or workflow does not limit the permissions of the GITHUB_TOKEN. Consider setting an explicit permissions block, using the following as a minimal starting point: {contents: read}
> CodeQL