### PR TITLE
fix: remove program id switcher in basic and counter programs

### DIFF
--- a/gill/gill-next-tailwind-basic/anchor/src/basic-exports.ts
+++ b/gill/gill-next-tailwind-basic/anchor/src/basic-exports.ts
@@ -1,23 +1,7 @@
 // Here we export some useful types and functions for interacting with the Anchor program.
-import { address } from 'gill'
-import { SolanaClusterId } from '@wallet-ui/react'
-import { BASIC_PROGRAM_ADDRESS } from './client/js'
 import BasicIDL from '../target/idl/basic.json'
 
 // Re-export the generated IDL and type
 export { BasicIDL }
-
-// This is a helper function to get the program ID for the Basic program depending on the cluster.
-export function getBasicProgramId(cluster: SolanaClusterId) {
-  switch (cluster) {
-    case 'solana:devnet':
-    case 'solana:testnet':
-      // This is the program ID for the Basic program on devnet and testnet.
-      return address('6z68wfurCMYkZG51s1Et9BJEd9nJGUusjHXNt4dGbNNF')
-    case 'solana:mainnet':
-    default:
-      return BASIC_PROGRAM_ADDRESS
-  }
-}
 
 export * from './client/js'

--- a/gill/gill-next-tailwind-basic/src/components/app-alert.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/app-alert.tsx
@@ -3,11 +3,11 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { ReactNode } from 'react'
 
 export function AppAlert({
-  action,
+  action = null,
   children,
   className = '',
 }: {
-  action: ReactNode
+  action?: ReactNode
   children: ReactNode
   className?: string
 }) {

--- a/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
+++ b/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
@@ -1,9 +1,0 @@
-import { useSolana } from '@/components/solana/use-solana'
-import { useMemo } from 'react'
-import { getBasicProgramId } from '@project/anchor'
-
-export function useBasicProgramId() {
-  const { cluster } = useSolana()
-
-  return useMemo(() => getBasicProgramId(cluster.id), [cluster])
-}

--- a/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
+++ b/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
@@ -1,12 +1,12 @@
+import { BASIC_PROGRAM_ADDRESS } from '@project/anchor'
 import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
-import { getBasicProgramId } from '@project/anchor'
 
 export function useGetProgramAccountQuery() {
   const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-program-account', { cluster }],
-    queryFn: () => client.rpc.getAccountInfo(getBasicProgramId(cluster.id)).send(),
+    queryFn: () => client.rpc.getAccountInfo(BASIC_PROGRAM_ADDRESS).send(),
   })
 }

--- a/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-greet-mutation.ts
+++ b/gill/gill-next-tailwind-basic/src/features/basic/data-access/use-greet-mutation.ts
@@ -1,19 +1,17 @@
-import { getGreetInstruction } from '@project/anchor'
+import { BASIC_PROGRAM_ADDRESS, getGreetInstruction } from '@project/anchor'
 import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { toastTx } from '@/components/toast-tx'
 import { useWalletTransactionSignAndSend } from '@/components/solana/use-wallet-transaction-sign-and-send'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
-import { useBasicProgramId } from './use-basic-program-id'
 
 export function useGreetMutation() {
-  const programAddress = useBasicProgramId()
   const txSigner = useWalletUiSigner()
   const signAndSend = useWalletTransactionSignAndSend()
 
   return useMutation({
     mutationFn: async () => {
-      return await signAndSend(getGreetInstruction({ programAddress }), txSigner)
+      return await signAndSend(getGreetInstruction({ programAddress: BASIC_PROGRAM_ADDRESS }), txSigner)
     },
     onSuccess: (signature) => {
       toastTx(signature)

--- a/gill/gill-next-tailwind-basic/src/features/basic/ui/basic-ui-program-explorer-link.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/basic/ui/basic-ui-program-explorer-link.tsx
@@ -1,9 +1,7 @@
-import { useBasicProgramId } from '@/features/basic/data-access/use-basic-program-id'
+import { BASIC_PROGRAM_ADDRESS } from '@project/anchor'
 import { AppExplorerLink } from '@/components/app-explorer-link'
 import { ellipsify } from '@wallet-ui/react'
 
 export function BasicUiProgramExplorerLink() {
-  const programId = useBasicProgramId()
-
-  return <AppExplorerLink address={programId.toString()} label={ellipsify(programId.toString())} />
+  return <AppExplorerLink address={BASIC_PROGRAM_ADDRESS} label={ellipsify(BASIC_PROGRAM_ADDRESS)} />
 }

--- a/gill/gill-next-tailwind-basic/src/features/basic/ui/basic-ui-program.tsx
+++ b/gill/gill-next-tailwind-basic/src/features/basic/ui/basic-ui-program.tsx
@@ -1,6 +1,10 @@
 import { useGetProgramAccountQuery } from '@/features/basic/data-access/use-get-program-account-query'
 
+import { AppAlert } from '@/components/app-alert'
+import { useSolana } from '@/components/solana/use-solana'
+
 export function BasicUiProgram() {
+  const { cluster } = useSolana()
   const query = useGetProgramAccountQuery()
 
   if (query.isLoading) {
@@ -8,9 +12,7 @@ export function BasicUiProgram() {
   }
   if (!query.data?.value) {
     return (
-      <div className="alert alert-info flex justify-center">
-        <span>Program account not found. Make sure you have deployed the program and are on the correct cluster.</span>
-      </div>
+      <AppAlert>Program account not found on {cluster.label}. Be sure to deploy your program and try again.</AppAlert>
     )
   }
   return (

--- a/gill/gill-next-tailwind-counter/anchor/src/counter-exports.ts
+++ b/gill/gill-next-tailwind-counter/anchor/src/counter-exports.ts
@@ -1,6 +1,5 @@
 // Here we export some useful types and functions for interacting with the Anchor program.
-import { Account, address, getBase58Decoder, SolanaClient } from 'gill'
-import { SolanaClusterId } from '@wallet-ui/react'
+import { Account, getBase58Decoder, SolanaClient } from 'gill'
 import { getProgramAccountsDecoded } from './helpers/get-program-accounts-decoded'
 import { Counter, COUNTER_DISCRIMINATOR, COUNTER_PROGRAM_ADDRESS, getCounterDecoder } from './client/js'
 import CounterIDL from '../target/idl/counter.json'
@@ -9,19 +8,6 @@ export type CounterAccount = Account<Counter, string>
 
 // Re-export the generated IDL and type
 export { CounterIDL }
-
-// This is a helper function to get the program ID for the Counter program depending on the cluster.
-export function getCounterProgramId(cluster: SolanaClusterId) {
-  switch (cluster) {
-    case 'solana:devnet':
-    case 'solana:testnet':
-      // This is the program ID for the Counter program on devnet and testnet.
-      return address('Count3AcZucFDPSFBAeHkQ6AvttieKUkyJ8HiQGhQwe')
-    case 'solana:mainnet':
-    default:
-      return COUNTER_PROGRAM_ADDRESS
-  }
-}
 
 export * from './client/js'
 

--- a/gill/gill-next-tailwind-counter/src/components/app-alert.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/app-alert.tsx
@@ -3,11 +3,11 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { ReactNode } from 'react'
 
 export function AppAlert({
-  action,
+  action = null,
   children,
   className = '',
 }: {
-  action: ReactNode
+  action?: ReactNode
   children: ReactNode
   className?: string
 }) {

--- a/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
+++ b/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
@@ -1,8 +1,0 @@
-import { useSolana } from '@/components/solana/use-solana'
-import { useMemo } from 'react'
-import { getCounterProgramId } from '@project/anchor'
-
-export function useCounterProgramId() {
-  const { cluster } = useSolana()
-  return useMemo(() => getCounterProgramId(cluster.id), [cluster])
-}

--- a/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
+++ b/gill/gill-next-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
@@ -1,16 +1,15 @@
+import { COUNTER_PROGRAM_ADDRESS } from '@project/anchor'
 import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useClusterVersion } from '@/features/cluster/data-access/use-cluster-version'
-import { useCounterProgramId } from './use-counter-program-id'
 
 export function useCounterProgram() {
   const { client, cluster } = useSolana()
-  const programId = useCounterProgramId()
   const query = useClusterVersion()
 
   return useQuery({
     retry: false,
     queryKey: ['get-program-account', { cluster, clusterVersion: query.data }],
-    queryFn: () => client.rpc.getAccountInfo(programId).send(),
+    queryFn: () => client.rpc.getAccountInfo(COUNTER_PROGRAM_ADDRESS).send(),
   })
 }

--- a/gill/gill-next-tailwind-counter/src/features/counter/ui/counter-ui-program-explorer-link.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/counter/ui/counter-ui-program-explorer-link.tsx
@@ -1,10 +1,7 @@
+import { COUNTER_PROGRAM_ADDRESS } from '@project/anchor'
 import { AppExplorerLink } from '@/components/app-explorer-link'
 import { ellipsify } from '@wallet-ui/react'
 
-import { useCounterProgramId } from '@/features/counter/data-access/use-counter-program-id'
-
 export function CounterUiProgramExplorerLink() {
-  const programId = useCounterProgramId()
-
-  return <AppExplorerLink address={programId.toString()} label={ellipsify(programId.toString())} />
+  return <AppExplorerLink address={COUNTER_PROGRAM_ADDRESS} label={ellipsify(COUNTER_PROGRAM_ADDRESS)} />
 }

--- a/gill/gill-next-tailwind-counter/src/features/counter/ui/counter-ui-program-guard.tsx
+++ b/gill/gill-next-tailwind-counter/src/features/counter/ui/counter-ui-program-guard.tsx
@@ -1,8 +1,11 @@
 import { ReactNode } from 'react'
 
+import { AppAlert } from '@/components/app-alert'
+import { useSolana } from '@/components/solana/use-solana'
 import { useCounterProgram } from '@/features/counter/data-access/use-counter-program'
 
 export function CounterUiProgramGuard({ children }: { children: ReactNode }) {
+  const { cluster } = useSolana()
   const programAccountQuery = useCounterProgram()
 
   if (programAccountQuery.isLoading) {
@@ -11,9 +14,7 @@ export function CounterUiProgramGuard({ children }: { children: ReactNode }) {
 
   if (!programAccountQuery.data?.value) {
     return (
-      <div className="alert alert-info flex justify-center">
-        <span>Program account not found. Make sure you have deployed the program and are on the correct cluster.</span>
-      </div>
+      <AppAlert>Program account not found on {cluster.label}. Be sure to deploy your program and try again.</AppAlert>
     )
   }
 

--- a/gill/gill-react-vite-tailwind-basic/anchor/src/basic-exports.ts
+++ b/gill/gill-react-vite-tailwind-basic/anchor/src/basic-exports.ts
@@ -1,23 +1,7 @@
 // Here we export some useful types and functions for interacting with the Anchor program.
-import { address } from 'gill'
-import { SolanaClusterId } from '@wallet-ui/react'
-import { BASIC_PROGRAM_ADDRESS } from './client/js'
 import BasicIDL from '../target/idl/basic.json'
 
 // Re-export the generated IDL and type
 export { BasicIDL }
-
-// This is a helper function to get the program ID for the Basic program depending on the cluster.
-export function getBasicProgramId(cluster: SolanaClusterId) {
-  switch (cluster) {
-    case 'solana:devnet':
-    case 'solana:testnet':
-      // This is the program ID for the Basic program on devnet and testnet.
-      return address('6z68wfurCMYkZG51s1Et9BJEd9nJGUusjHXNt4dGbNNF')
-    case 'solana:mainnet':
-    default:
-      return BASIC_PROGRAM_ADDRESS
-  }
-}
 
 export * from './client/js'

--- a/gill/gill-react-vite-tailwind-basic/src/components/app-alert.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/components/app-alert.tsx
@@ -3,11 +3,11 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { ReactNode } from 'react'
 
 export function AppAlert({
-  action,
+  action = null,
   children,
   className = '',
 }: {
-  action: ReactNode
+  action?: ReactNode
   children: ReactNode
   className?: string
 }) {

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-basic-program-id.ts
@@ -1,9 +1,0 @@
-import { useSolana } from '@/components/solana/use-solana'
-import { useMemo } from 'react'
-import { getBasicProgramId } from '@project/anchor'
-
-export function useBasicProgramId() {
-  const { cluster } = useSolana()
-
-  return useMemo(() => getBasicProgramId(cluster.id), [cluster])
-}

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-get-program-account-query.ts
@@ -1,12 +1,12 @@
 import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
-import { getBasicProgramId } from '@project/anchor'
+import { BASIC_PROGRAM_ADDRESS } from '@project/anchor'
 
 export function useGetProgramAccountQuery() {
   const { client, cluster } = useSolana()
 
   return useQuery({
     queryKey: ['get-program-account', { cluster }],
-    queryFn: () => client.rpc.getAccountInfo(getBasicProgramId(cluster.id)).send(),
+    queryFn: () => client.rpc.getAccountInfo(BASIC_PROGRAM_ADDRESS).send(),
   })
 }

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-greet-mutation.ts
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/data-access/use-greet-mutation.ts
@@ -1,19 +1,17 @@
-import { getGreetInstruction } from '@project/anchor'
+import { BASIC_PROGRAM_ADDRESS, getGreetInstruction } from '@project/anchor'
 import { useMutation } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { toastTx } from '@/components/toast-tx'
 import { useWalletTransactionSignAndSend } from '@/components/solana/use-wallet-transaction-sign-and-send'
 import { useWalletUiSigner } from '@/components/solana/use-wallet-ui-signer'
-import { useBasicProgramId } from './use-basic-program-id'
 
 export function useGreetMutation() {
-  const programAddress = useBasicProgramId()
   const txSigner = useWalletUiSigner()
   const signAndSend = useWalletTransactionSignAndSend()
 
   return useMutation({
     mutationFn: async () => {
-      return await signAndSend(getGreetInstruction({ programAddress }), txSigner)
+      return await signAndSend(getGreetInstruction({ programAddress: BASIC_PROGRAM_ADDRESS }), txSigner)
     },
     onSuccess: (signature) => {
       toastTx(signature)

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/ui/basic-ui-program-explorer-link.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/ui/basic-ui-program-explorer-link.tsx
@@ -1,9 +1,7 @@
-import { useBasicProgramId } from '@/features/basic/data-access/use-basic-program-id'
+import { BASIC_PROGRAM_ADDRESS } from '@project/anchor'
 import { AppExplorerLink } from '@/components/app-explorer-link'
 import { ellipsify } from '@wallet-ui/react'
 
 export function BasicUiProgramExplorerLink() {
-  const programId = useBasicProgramId()
-
-  return <AppExplorerLink address={programId.toString()} label={ellipsify(programId.toString())} />
+  return <AppExplorerLink address={BASIC_PROGRAM_ADDRESS} label={ellipsify(BASIC_PROGRAM_ADDRESS)} />
 }

--- a/gill/gill-react-vite-tailwind-basic/src/features/basic/ui/basic-ui-program.tsx
+++ b/gill/gill-react-vite-tailwind-basic/src/features/basic/ui/basic-ui-program.tsx
@@ -1,6 +1,10 @@
 import { useGetProgramAccountQuery } from '@/features/basic/data-access/use-get-program-account-query'
 
+import { AppAlert } from '@/components/app-alert'
+import { useSolana } from '@/components/solana/use-solana'
+
 export function BasicUiProgram() {
+  const { cluster } = useSolana()
   const query = useGetProgramAccountQuery()
 
   if (query.isLoading) {
@@ -8,9 +12,7 @@ export function BasicUiProgram() {
   }
   if (!query.data?.value) {
     return (
-      <div className="alert alert-info flex justify-center">
-        <span>Program account not found. Make sure you have deployed the program and are on the correct cluster.</span>
-      </div>
+      <AppAlert>Program account not found on {cluster.label}. Be sure to deploy your program and try again.</AppAlert>
     )
   }
   return (

--- a/gill/gill-react-vite-tailwind-counter/anchor/src/counter-exports.ts
+++ b/gill/gill-react-vite-tailwind-counter/anchor/src/counter-exports.ts
@@ -1,6 +1,5 @@
 // Here we export some useful types and functions for interacting with the Anchor program.
-import { Account, address, getBase58Decoder, SolanaClient } from 'gill'
-import { SolanaClusterId } from '@wallet-ui/react'
+import { Account, getBase58Decoder, SolanaClient } from 'gill'
 import { getProgramAccountsDecoded } from './helpers/get-program-accounts-decoded'
 import { Counter, COUNTER_DISCRIMINATOR, COUNTER_PROGRAM_ADDRESS, getCounterDecoder } from './client/js'
 import CounterIDL from '../target/idl/counter.json'
@@ -9,19 +8,6 @@ export type CounterAccount = Account<Counter, string>
 
 // Re-export the generated IDL and type
 export { CounterIDL }
-
-// This is a helper function to get the program ID for the Counter program depending on the cluster.
-export function getCounterProgramId(cluster: SolanaClusterId) {
-  switch (cluster) {
-    case 'solana:devnet':
-    case 'solana:testnet':
-      // This is the program ID for the Counter program on devnet and testnet.
-      return address('6z68wfurCMYkZG51s1Et9BJEd9nJGUusjHXNt4dGbNNF')
-    case 'solana:mainnet':
-    default:
-      return COUNTER_PROGRAM_ADDRESS
-  }
-}
 
 export * from './client/js'
 

--- a/gill/gill-react-vite-tailwind-counter/src/components/app-alert.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/components/app-alert.tsx
@@ -3,11 +3,11 @@ import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { ReactNode } from 'react'
 
 export function AppAlert({
-  action,
+  action = null,
   children,
   className = '',
 }: {
-  action: ReactNode
+  action?: ReactNode
   children: ReactNode
   className?: string
 }) {

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program-id.ts
@@ -1,8 +1,0 @@
-import { useMemo } from 'react'
-import { getCounterProgramId } from '@project/anchor'
-import { useSolana } from '@/components/solana/use-solana'
-
-export function useCounterProgramId() {
-  const { cluster } = useSolana()
-  return useMemo(() => getCounterProgramId(cluster.id), [cluster])
-}

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/data-access/use-counter-program.ts
@@ -1,16 +1,15 @@
+import { COUNTER_PROGRAM_ADDRESS } from '@project/anchor'
 import { useSolana } from '@/components/solana/use-solana'
 import { useQuery } from '@tanstack/react-query'
 import { useClusterVersion } from '@/features/cluster/data-access/use-cluster-version'
-import { useCounterProgramId } from './use-counter-program-id'
 
 export function useCounterProgram() {
   const { client, cluster } = useSolana()
-  const programId = useCounterProgramId()
   const query = useClusterVersion()
 
   return useQuery({
     retry: false,
     queryKey: ['get-program-account', { cluster, clusterVersion: query.data }],
-    queryFn: () => client.rpc.getAccountInfo(programId).send(),
+    queryFn: () => client.rpc.getAccountInfo(COUNTER_PROGRAM_ADDRESS).send(),
   })
 }

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/ui/counter-ui-program-explorer-link.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/ui/counter-ui-program-explorer-link.tsx
@@ -1,10 +1,7 @@
+import { COUNTER_PROGRAM_ADDRESS } from '@project/anchor'
 import { AppExplorerLink } from '@/components/app-explorer-link'
 import { ellipsify } from '@wallet-ui/react'
 
-import { useCounterProgramId } from '@/features/counter/data-access/use-counter-program-id'
-
 export function CounterUiProgramExplorerLink() {
-  const programId = useCounterProgramId()
-
-  return <AppExplorerLink address={programId.toString()} label={ellipsify(programId.toString())} />
+  return <AppExplorerLink address={COUNTER_PROGRAM_ADDRESS} label={ellipsify(COUNTER_PROGRAM_ADDRESS)} />
 }

--- a/gill/gill-react-vite-tailwind-counter/src/features/counter/ui/counter-ui-program-guard.tsx
+++ b/gill/gill-react-vite-tailwind-counter/src/features/counter/ui/counter-ui-program-guard.tsx
@@ -1,8 +1,11 @@
 import { ReactNode } from 'react'
 
+import { AppAlert } from '@/components/app-alert'
+import { useSolana } from '@/components/solana/use-solana'
 import { useCounterProgram } from '@/features/counter/data-access/use-counter-program'
 
 export function CounterUiProgramGuard({ children }: { children: ReactNode }) {
+  const { cluster } = useSolana()
   const programAccountQuery = useCounterProgram()
 
   if (programAccountQuery.isLoading) {
@@ -11,9 +14,7 @@ export function CounterUiProgramGuard({ children }: { children: ReactNode }) {
 
   if (!programAccountQuery.data?.value) {
     return (
-      <div className="alert alert-info flex justify-center">
-        <span>Program account not found. Make sure you have deployed the program and are on the correct cluster.</span>
-      </div>
+      <AppAlert>Program account not found on {cluster.label}. Be sure to deploy your program and try again.</AppAlert>
     )
   }
 


### PR DESCRIPTION
Currently, the templates we generate have logic to switch the `programId` based on the cluster.

The idea behind this was that you can switch between different deployed program ID's based on the cluster.

However, this leads to issues and confusion as can be seen in #132 and potentially others.

In addition, now that I think about it, it doesn't logically make sense to have something like this because as soon as you start working on your program, the program we deployed on `devnet` and `testnet` are outdated and people will have to get rid of this logic or adjust it. 

This PR removes the whole concept to make the templates simpler, work more reliably and easier to reason about. 

I've updated the warning to inform the user that the program is not deployed to the cluster they are connected to:

<img width="970" height="678" alt="image" src="https://github.com/user-attachments/assets/f4cb22cb-a83a-4c10-ba39-b46c11ffbb57" />
