### PR TITLE
fix: make ClusterImport import dynamic to fix hydration error

### DIFF
--- a/gill/gill-next-tailwind-basic/src/components/app-header.tsx
+++ b/gill/gill-next-tailwind-basic/src/components/app-header.tsx
@@ -1,12 +1,16 @@
 'use client'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Menu, X } from 'lucide-react'
 import { ThemeSelect } from '@/components/theme-select'
 import { WalletDropdown } from '@/components/wallet-dropdown'
-import { ClusterDropdown } from '@/components/cluster-dropdown'
+
+const ClusterDropdown = dynamic(() => import('@/components/cluster-dropdown').then((m) => m.ClusterDropdown), {
+  ssr: false,
+})
 
 export function AppHeader({ links = [] }: { links: { label: string; path: string }[] }) {
   const pathname = usePathname()

--- a/gill/gill-next-tailwind-counter/src/components/app-header.tsx
+++ b/gill/gill-next-tailwind-counter/src/components/app-header.tsx
@@ -1,12 +1,16 @@
 'use client'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Menu, X } from 'lucide-react'
 import { ThemeSelect } from '@/components/theme-select'
 import { WalletDropdown } from '@/components/wallet-dropdown'
-import { ClusterDropdown } from '@/components/cluster-dropdown'
+
+const ClusterDropdown = dynamic(() => import('@/components/cluster-dropdown').then((m) => m.ClusterDropdown), {
+  ssr: false,
+})
 
 export function AppHeader({ links = [] }: { links: { label: string; path: string }[] }) {
   const pathname = usePathname()

--- a/gill/gill-next-tailwind/src/components/app-header.tsx
+++ b/gill/gill-next-tailwind/src/components/app-header.tsx
@@ -1,12 +1,16 @@
 'use client'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Menu, X } from 'lucide-react'
 import { ThemeSelect } from '@/components/theme-select'
 import { WalletDropdown } from '@/components/wallet-dropdown'
-import { ClusterDropdown } from '@/components/cluster-dropdown'
+
+const ClusterDropdown = dynamic(() => import('@/components/cluster-dropdown').then((m) => m.ClusterDropdown), {
+  ssr: false,
+})
 
 export function AppHeader({ links = [] }: { links: { label: string; path: string }[] }) {
   const pathname = usePathname()


### PR DESCRIPTION
## Problem

When a user selects a different cluster than is configured as the default, Next.js will raise an hydration error as the SSR component has a different value than what gets rendered on the client.

> Hydration failed because the server rendered text didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:


<img width="959" height="480" alt="image" src="https://github.com/user-attachments/assets/588a47e8-173b-481b-8dbb-4cb86a734403" />

## Changes 

This PR updates the header and makes the `ClusterImport` import dynamic as it's one of the [the suggested solutions](https://nextjs.org/docs/messages/react-hydration-error#solution-2-disabling-ssr-on-specific-components) for Next.
