### PR TITLE
feat: test all templates when workflow files change

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -55,6 +55,13 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             CHANGED_FILES="${{ steps.changed-files.outputs.changed_files }}"
 
+            # Check if any workflow or global config files changed - if so, test all templates
+            if echo "$CHANGED_FILES" | grep -q -E '^\.github/workflows/'; then
+              echo "Workflow files changed, testing all templates"
+              echo templates=$(echo $ALL_TEMPLATES | sed 's/ //g') | tee --append $GITHUB_OUTPUT
+              exit 0
+            fi
+
             # Extract template paths from changed files
             AFFECTED_TEMPLATES=$(echo "$CHANGED_FILES" | grep -E '^(community|gill|mobile|web3js)/' | cut -d'/' -f1-2 | sort -u || true)
 


### PR DESCRIPTION
Implements @beeman's suggestion from [PR #168](https://github.com/solana-foundation/templates/pull/168#discussion_r1818823456) to test all templates when workflow files are modified.

Added a check to detect if `.github/workflows/` files changed in a PR. If so, all templates are tested instead of only affected ones. Workflow changes affect how ALL templates are tested.