### PR TITLE
fix: add gill-node-solanax402 and zk-compression-airdrop to template.json

### DIFF
--- a/.github/workflows/templates.json
+++ b/.github/workflows/templates.json
@@ -1,5 +1,7 @@
 [
   "community/gill-jito-airdrop",
+  "community/gill-node-solanax402",
+  "community/zk-compression-airdrop",
   "gill/gill-next-tailwind",
   "gill/gill-next-tailwind-basic",
   "gill/gill-next-tailwind-counter",


### PR DESCRIPTION
Until the CI scripts use `npx -y create-solana-dapp@latest --list-template-ids`, the `templates.json` file must be maintained manually when new templates get added.

This is a manual update to get it up to date.