### PR TITLE
Fix template name generation for templates with variables

### DIFF
--- a/TEMPLATES.md
+++ b/TEMPLATES.md
@@ -158,14 +158,6 @@ Templates using @solana/web3.js (legacy)
 
 Templates maintained by the Solana community
 
-### [{{project-name}}](community/gill-node-solanax402)
-
-`gh:solana-foundation/templates/community/gill-node-solanax402`
-
-> x402 protocol implementation for Solana with Facilitator and Server apps using TypeScript and Gill SDK
-
-`solana` `x402` `payment` `protocol` `blockchain` `typescript` `gill`
-
 ### [gill-jito-airdrop](community/gill-jito-airdrop)
 
 `gh:solana-foundation/templates/community/gill-jito-airdrop`
@@ -173,6 +165,14 @@ Templates maintained by the Solana community
 > A modern, script-driven Solana airdrop template that distributes SOL to many recipients efficiently using a Merkle tree
 
 `nextjs` `react` `tailwind` `typescript` `wallet-ui`
+
+### [gill-node-solanax402](community/gill-node-solanax402)
+
+`gh:solana-foundation/templates/community/gill-node-solanax402`
+
+> x402 protocol implementation for Solana with Facilitator and Server apps using TypeScript and Gill SDK
+
+`solana` `x402` `payment` `protocol` `blockchain` `typescript` `gill`
 
 ### [x402-template](community/x402-template)
 

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -79,8 +79,11 @@ const extractTemplateMetadata = (dir: string, groupPath: string, directoryName: 
 
   const relativePath = join(groupPath, directoryName)
 
+  // Use directory name if package.json name contains template variables
+  const templateName = pkg.name.includes('{{') ? directoryName : pkg.name
+
   return ok({
-    name: pkg.name,
+    name: templateName,
     displayName: pkg.displayName,
     description: pkg.description || '',
     usecase: pkg.usecase,

--- a/templates.json
+++ b/templates.json
@@ -343,24 +343,6 @@
     "path": "community",
     "templates": [
       {
-        "description": "x402 protocol implementation for Solana with Facilitator and Server apps using TypeScript and Gill SDK",
-        "id": "gh:solana-foundation/templates/community/gill-node-solanax402",
-        "image": "community/gill-node-solanax402/og-image.png",
-        "keywords": [
-          "solana",
-          "x402",
-          "payment",
-          "protocol",
-          "blockchain",
-          "typescript",
-          "gill"
-        ],
-        "name": "{{project-name}}",
-        "path": "community/gill-node-solanax402",
-        "displayName": "x402 Express Server",
-        "usecase": "Payments"
-      },
-      {
         "description": "A modern, script-driven Solana airdrop template that distributes SOL to many recipients efficiently using a Merkle tree",
         "id": "gh:solana-foundation/templates/community/gill-jito-airdrop",
         "image": "community/gill-jito-airdrop/og-image.png",
@@ -375,6 +357,24 @@
         "path": "community/gill-jito-airdrop",
         "displayName": "Merkletree Airdrop",
         "usecase": "Airdrop"
+      },
+      {
+        "description": "x402 protocol implementation for Solana with Facilitator and Server apps using TypeScript and Gill SDK",
+        "id": "gh:solana-foundation/templates/community/gill-node-solanax402",
+        "image": "community/gill-node-solanax402/og-image.png",
+        "keywords": [
+          "solana",
+          "x402",
+          "payment",
+          "protocol",
+          "blockchain",
+          "typescript",
+          "gill"
+        ],
+        "name": "gill-node-solanax402",
+        "path": "community/gill-node-solanax402",
+        "displayName": "x402 Express Server",
+        "usecase": "Payments"
       },
       {
         "description": "Next.js Solana starter with X402 payment protocol integration",


### PR DESCRIPTION
The generation script was using {{project-name}} placeholder from package.json as the template name in templates.json, causing broken links. Now detects template variables and uses directory name instead.

Fixes x402 Express Server template.