### PR TITLE
docs: update README links and examples for phantom-embedded templates

### DIFF
--- a/community/phantom-embedded-js/README.md
+++ b/community/phantom-embedded-js/README.md
@@ -205,7 +205,7 @@ pnpm preview
 
 - [Phantom Browser SDK Docs](https://docs.phantom.com/sdks/browser-sdk) - Official SDK documentation
 - [Phantom Developer Portal](https://phantom.com/portal) - Get your App ID
-- [Solana Web3.js Docs](https://solana-labs.github.io/solana-web3.js/) - Solana JavaScript SDK
+- [Solana Web3.js Docs](https://github.com/solana-foundation/solana-web3.js) - Solana JavaScript SDK
 - [Solana Cookbook](https://solanacookbook.com/) - Development recipes
 
 ## Support

--- a/community/phantom-embedded-react-native/README.md
+++ b/community/phantom-embedded-react-native/README.md
@@ -2,8 +2,6 @@
 
 A minimal Expo starter template for integrating Phantom's embedded user wallets on Solana for mobile apps.
 
-![Phantom Embedded Wallet](https://phantom.app/img/logo.svg)
-
 ## ✨ Features
 
 - 🔐 **Phantom Connect Authentication** - Secure OAuth-based wallet connection
@@ -51,8 +49,8 @@ Edit `.env` and add your Phantom App ID:
 
 ```env
 EXPO_PUBLIC_PHANTOM_APP_ID=your-app-id-here
-EXPO_PUBLIC_APP_SCHEME=phantomwallet
-EXPO_PUBLIC_SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+EXPO_PUBLIC_APP_SCHEME=your-app-scheme
+EXPO_PUBLIC_SOLANA_RPC_URL=your-prefered-rpc
 ```
 
 ### 3. Get Your Phantom App ID
@@ -362,7 +360,7 @@ const short = truncateAddress('5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp...', 4)
 - [Phantom React Native SDK Docs](https://docs.phantom.com/sdks/react-native-sdk)
 - [Expo Development Builds](https://docs.expo.dev/develop/development-builds/introduction/)
 - [Expo Router Docs](https://docs.expo.dev/router/introduction/)
-- [Solana Web3.js Docs](https://solana-labs.github.io/solana-web3.js/)
+- [Solana Web3.js Docs](https://github.com/solana-foundation/solana-web3.js)
 
 ## 💬 Support
 

--- a/community/phantom-embedded-react/README.md
+++ b/community/phantom-embedded-react/README.md
@@ -17,7 +17,7 @@ A modern, production-ready starter template for building Solana dApps with the [
 - [Next.js](https://nextjs.org/) - React framework
 - [@phantom/react-sdk](https://docs.phantom.com/sdks/react-sdk) - Phantom Connect SDK for React
 - [@phantom/browser-sdk](https://docs.phantom.com/sdks/browser-sdk) - Phantom Connect SDK core
-- [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/) - Solana JavaScript API
+- [@solana/web3.js](https://github.com/solana-foundation/solana-web3.js) - Solana JavaScript API
 - [Tailwind CSS](https://tailwindcss.com/) - Utility-first CSS framework
 
 ## Getting Started


### PR DESCRIPTION
- Update Solana Web3.js documentation links to use solana-foundation GitHub URL
- Remove image reference from react-native README
- Update example app scheme to use generic placeholder in react-native template