### PR TITLE
fix: correct create-solana-dapp commands in kit template READMEs

### DIFF
--- a/kit/nextjs-anchor/README.md
+++ b/kit/nextjs-anchor/README.md
@@ -5,7 +5,7 @@ Next.js starter with Tailwind CSS, `@solana/react-hooks`, and an Anchor vault pr
 ## Getting Started
 
 ```shell
-npx create-solana-dapp@latest -t kit/nextjs-anchor
+npx -y create-solana-dapp@latest -t solana-foundation/templates/kit/nextjs-anchor
 ```
 
 ```shell

--- a/kit/nextjs/README.md
+++ b/kit/nextjs/README.md
@@ -5,7 +5,7 @@ Next.js starter with Tailwind CSS and `@solana/kit` for wallet connection and So
 ## Getting Started
 
 ```shell
-npx create-solana-dapp@latest -t kit/nextjs
+npx -y create-solana-dapp@latest -t solana-foundation/templates/kit/nextjs
 ```
 
 ```shell

--- a/kit/react-vite-anchor/README.md
+++ b/kit/react-vite-anchor/README.md
@@ -5,7 +5,7 @@ React + Vite starter with Tailwind CSS, `@solana/react-hooks`, and an Anchor vau
 ## Getting Started
 
 ```shell
-npx create-solana-dapp@latest -t kit/vite-anchor
+npx -y create-solana-dapp@latest -t solana-foundation/templates/kit/react-vite-anchor
 ```
 
 ```shell

--- a/kit/react-vite/README.md
+++ b/kit/react-vite/README.md
@@ -5,7 +5,7 @@ React + Vite starter with Tailwind CSS and `@solana/react-hooks` for wallet conn
 ## Getting Started
 
 ```shell
-npx create-solana-dapp@latest -t kit/vite
+npx -y create-solana-dapp@latest -t solana-foundation/templates/kit/react-vite
 ```
 
 ```shell


### PR DESCRIPTION
## Summary
- Fix incorrect `create-solana-dapp` commands in kit template READMEs
- Commands now use the full template path format (`solana-foundation/templates/kit/...`) matching the template site modal
- Also adds the `-y` flag for npm as used in the template site

## Changes
- `kit/nextjs`: `kit/nextjs` → `solana-foundation/templates/kit/nextjs`
- `kit/nextjs-anchor`: `kit/nextjs-anchor` → `solana-foundation/templates/kit/nextjs-anchor`
- `kit/react-vite`: `kit/vite` → `solana-foundation/templates/kit/react-vite`
- `kit/react-vite-anchor`: `kit/vite-anchor` → `solana-foundation/templates/kit/react-vite-anchor`

## Test plan
- [ ] Verify the commands work by running them in a fresh directory