### PR TITLE
fix(x402-solana-rust): skip postinstall in CI and monorepo installs

### DIFF
--- a/community/x402-solana-rust/create.js
+++ b/community/x402-solana-rust/create.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+if (process.env.CI || process.env.PNPM_SCRIPT_SRC_DIR) {
+  process.exit(0)
+}
+
 const fs = require('fs')
 const path = require('path')
 const readline = require('readline')


### PR DESCRIPTION
**Issue:** The `x402-solana-rust` template has a `postinstall` script that runs `create.js`, which is an interactive wizard that scaffolds a Rust project

When running `pnpm install` at the monorepo root, pnpm executes all workspace packages' lifecycle scripts. This causes `create.js` to run automatically, creating an unwanted `x402-solana-backend/` directory inside the template folder.

**Fix:** Added an early exit check in `create.js` to skip execution when:
- Running in CI (`process.env.CI`)
- Running as part of a pnpm workspace install (`process.env.PNPM_SCRIPT_SRC_DIR`)

This ensures the script only runs when users explicitly scaffold the template, not during monorepo maintenance or working in other templates 