### PR TITLE
ci: skip template tests on unrelated workflow changes

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -57,9 +57,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             CHANGED_FILES="${{ steps.changed-files.outputs.changed_files }}"
 
-            # Check if any workflow or global config files changed - if so, test all templates (except community)
-            if echo "$CHANGED_FILES" | grep -q -E '^\.github/workflows/'; then
-              echo "Workflow files changed, testing all templates except community"
+            # Check if test-related workflow or action files changed - if so, test all templates (except community)
+            if echo "$CHANGED_FILES" | grep -q -E '^\.github/workflows/(test-templates\.yml|actions/)'; then
+              echo "Test workflow or actions changed, testing all templates except community"
               echo templates=$(echo $TESTABLE_TEMPLATES | sed 's/ //g') | tee --append $GITHUB_OUTPUT
               exit 0
             fi


### PR DESCRIPTION
Any change under .github/workflows/ was triggering all 96 template test jobs, even for unrelated workflows like dependabot-lockfile.yml or stale-prs.yml.

This narrows the check so all template tests only run when the actual test workflow or its actions change (test-templates.yml, .github/workflows/actions/).