### PR TITLE
fix: add missing feature flags to pinocchio template dependencies

### DIFF
--- a/pinocchio/pinocchio-counter/Cargo.toml
+++ b/pinocchio/pinocchio-counter/Cargo.toml
@@ -28,6 +28,6 @@ solana-address = { version = "2.0", features = ["curve25519"] }
 pinocchio-log = "^0.5.1"
 pinocchio-system = "^0.5.0"
 thiserror = "^2.0.17"
-borsh = "^1.6.0"
+borsh = { version = "^1.6.0", features = ["derive"] }
 num-derive = "^0.4.0"
 num-traits = "^0.2.0"

--- a/pinocchio/pinocchio-counter/clients/rust/Cargo.toml
+++ b/pinocchio/pinocchio-counter/clients/rust/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 borsh = { workspace = true }
 solana-account-info = "3.1.0"
-solana-pubkey = "4.0.0"
+solana-pubkey = { version = "4.0.0", features = ["borsh"] }
 solana-address = "2.0.0"
 solana-instruction = "3.1.0"
 solana-cpi = "3.0.1"


### PR DESCRIPTION
## Summary

- Enable `borsh` `derive` feature in workspace `Cargo.toml` so `#[derive(BorshSerialize, BorshDeserialize)]` works on generated structs
- Enable `solana-pubkey` `borsh` feature in `clients/rust/Cargo.toml` so `Pubkey` implements `BorshSerialize`/`BorshDeserialize`

Closes #303