### PR TITLE
ci: ignore agent files in template format checks

### DIFF
--- a/kit/nextjs-anchor/.prettierignore
+++ b/kit/nextjs-anchor/.prettierignore
@@ -2,3 +2,4 @@
 node_modules
 pnpm-lock.yaml
 app/generated
+.agents

--- a/kit/nextjs/.prettierignore
+++ b/kit/nextjs/.prettierignore
@@ -1,3 +1,4 @@
 .next
 node_modules
 pnpm-lock.yaml
+.agents

--- a/kit/react-vite-anchor/.prettierignore
+++ b/kit/react-vite-anchor/.prettierignore
@@ -2,3 +2,4 @@ dist
 node_modules
 pnpm-lock.yaml
 src/generated
+.agents

--- a/kit/react-vite/.prettierignore
+++ b/kit/react-vite/.prettierignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 pnpm-lock.yaml
+.agents

--- a/mobile/kit-expo-minimal/.prettierignore
+++ b/mobile/kit-expo-minimal/.prettierignore
@@ -6,3 +6,4 @@
 /ios
 /tmp
 pnpm-lock.yaml
+.agents

--- a/mobile/kit-expo-uniwind/.prettierignore
+++ b/mobile/kit-expo-uniwind/.prettierignore
@@ -6,3 +6,4 @@
 /ios
 /tmp
 pnpm-lock.yaml
+.agents

--- a/mobile/web3js-expo-minimal/.prettierignore
+++ b/mobile/web3js-expo-minimal/.prettierignore
@@ -6,3 +6,4 @@
 /ios
 /tmp
 pnpm-lock.yaml
+.agents

--- a/mobile/web3js-expo-paper/.prettierignore
+++ b/mobile/web3js-expo-paper/.prettierignore
@@ -6,3 +6,4 @@
 /ios
 /tmp
 pnpm-lock.yaml
+.agents

--- a/mobile/web3js-expo/.prettierignore
+++ b/mobile/web3js-expo/.prettierignore
@@ -6,3 +6,4 @@
 /ios
 /tmp
 pnpm-lock.yaml
+.agents

--- a/web3js/web3js-next-tailwind-basic/.prettierignore
+++ b/web3js/web3js-next-tailwind-basic/.prettierignore
@@ -12,3 +12,4 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+.agents

--- a/web3js/web3js-next-tailwind-counter/.prettierignore
+++ b/web3js/web3js-next-tailwind-counter/.prettierignore
@@ -12,3 +12,4 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+.agents

--- a/web3js/web3js-next-tailwind/.prettierignore
+++ b/web3js/web3js-next-tailwind/.prettierignore
@@ -6,3 +6,4 @@
 package-lock.json
 pnpm-lock.yaml
 yarn.lock
+.agents

--- a/web3js/web3js-react-vite-tailwind-basic/.prettierignore
+++ b/web3js/web3js-react-vite-tailwind-basic/.prettierignore
@@ -9,3 +9,4 @@
 /coverage
 tmp
 pnpm-lock.yaml
+.agents

--- a/web3js/web3js-react-vite-tailwind-counter/.prettierignore
+++ b/web3js/web3js-react-vite-tailwind-counter/.prettierignore
@@ -9,3 +9,4 @@
 /coverage
 tmp
 pnpm-lock.yaml
+.agents

--- a/web3js/web3js-react-vite-tailwind/.prettierignore
+++ b/web3js/web3js-react-vite-tailwind/.prettierignore
@@ -3,3 +3,4 @@
 /coverage
 tmp
 pnpm-lock.yaml
+.agents


### PR DESCRIPTION
Adds `.agents` to the `.prettierignore` files for the affected JS templates.

`create-solana-dapp` can install local agent skill files under `.agents`. Those files are not part of the templates, but `prettier --check .` was checking them and failing CI before the template build could finish.

Verified locally with a fake badly formatted `.agents/skills/...` markdown file: format check passes with this ignore rule and fails when the rule is removed.

This is a draft so CI can confirm whether any other latent failures remain.