### PR TITLE
chore(docs): replace anchor-lang introduction URLs with canonical /docs/

### DIFF
--- a/kit/nextjs-anchor/README.md
+++ b/kit/nextjs-anchor/README.md
@@ -159,7 +159,7 @@ This uses [Codama](https://github.com/codama-idl/codama) to generate a type-safe
 ## Learn More
 
 - [Solana Docs](https://solana.com/docs) — core concepts and guides
-- [Anchor Docs](https://www.anchor-lang.com/docs/introduction) — program development framework
+- [Anchor Docs](https://www.anchor-lang.com/docs/) — program development framework
 - [Deploying Programs](https://solana.com/docs/programs/deploying) — deployment guide
 - [@solana/kit](https://github.com/anza-xyz/kit) — Solana JavaScript SDK
 - [Codama](https://github.com/codama-idl/codama) — client generation from IDL

--- a/kit/nextjs-anchor/app/page.tsx
+++ b/kit/nextjs-anchor/app/page.tsx
@@ -113,7 +113,7 @@ export default function Home() {
                 <p className="text-sm leading-relaxed text-foreground/40">
                   The vault is an{" "}
                   <a
-                    href="https://www.anchor-lang.com/docs/introduction"
+                    href="https://www.anchor-lang.com/docs/"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline underline-offset-2"
@@ -134,7 +134,7 @@ export default function Home() {
                     <span aria-hidden="true">&rarr;</span>
                   </a>
                   <a
-                    href="https://www.anchor-lang.com/docs/introduction"
+                    href="https://www.anchor-lang.com/docs/"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-1 text-sm font-medium text-foreground/70 underline underline-offset-4 transition-colors hover:text-foreground"

--- a/kit/nextjs/app/page.tsx
+++ b/kit/nextjs/app/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 import { useWalletConnection } from "@solana/react-hooks";
+export default function Home() {
+  const { connectors, connect, disconnect, wallet, status } =
+    useWalletConnection();
 
+  const address = wallet?.account.address.toString();
   return (
     <div className="relative min-h-screen overflow-x-clip bg-bg1 text-foreground">
       <main className="relative z-10 mx-auto flex min-h-screen max-w-4xl flex-col gap-10 border-x border-border-low px-6 py-16">

--- a/kit/nextjs/app/page.tsx
+++ b/kit/nextjs/app/page.tsx
@@ -1,12 +1,6 @@
 "use client";
 import { useWalletConnection } from "@solana/react-hooks";
 
-export default function Home() {
-  const { connectors, connect, disconnect, wallet, status } =
-    useWalletConnection();
-
-  const address = wallet?.account.address.toString();
-
   return (
     <div className="relative min-h-screen overflow-x-clip bg-bg1 text-foreground">
       <main className="relative z-10 mx-auto flex min-h-screen max-w-4xl flex-col gap-10 border-x border-border-low px-6 py-16">
@@ -49,7 +43,7 @@ export default function Home() {
               <div>
                 <a
                   className="font-medium underline underline-offset-2"
-                  href="https://www.anchor-lang.com/docs/introduction"
+                  href="https://www.anchor-lang.com/docs/"
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/kit/react-vite-anchor/src/App.tsx
+++ b/kit/react-vite-anchor/src/App.tsx
@@ -49,7 +49,7 @@ export default function App() {
               <div>
                 <a
                   className="font-medium underline underline-offset-2"
-                  href="https://www.anchor-lang.com/docs/introduction"
+                  href="https://www.anchor-lang.com/docs/"
                   target="_blank"
                   rel="noreferrer"
                 >

--- a/kit/react-vite/src/App.tsx
+++ b/kit/react-vite/src/App.tsx
@@ -48,7 +48,7 @@ export default function App() {
               <div>
                 <a
                   className="font-medium underline underline-offset-2"
-                  href="https://www.anchor-lang.com/docs/introduction"
+                  href="https://www.anchor-lang.com/docs/"
                   target="_blank"
                   rel="noreferrer"
                 >


### PR DESCRIPTION
## What
The Anchor docs links in the scaffold templates point to
`https://www.anchor-lang.com/docs/introduction` which returns a 404.
<img width="1608" height="727" alt="Screenshot 2026-06-07 154821" src="https://github.com/user-attachments/assets/b9c31f21-3e0d-411d-837d-b5a89c099d70" />

## Why
The Anchor documentation was restructured and the `/docs/introduction`
path no longer exists. The canonical entry point is now
`https://www.anchor-lang.com/docs`.
<img width="1308" height="823" alt="Screenshot 2026-06-07 154952" src="https://github.com/user-attachments/assets/1b0f3cba-ad1e-4e47-a54c-e49aab120f3a" />


## Changes

- Replaced all occurrences of `anchor-lang.com/docs/introduction` with
  `anchor-lang.com/docs` across the affected template files

## How to reproduce the bug

1. Run `npx create-solana-dapp@latest`
2. Start the app and run localnet
3. Click the "Anchor Docs" link on the home page
4. Observe 404 error

## References

- Anchor docs: https://www.anchor-lang.com/docs