### PR TITLE
fix: remove duplicate snapshot key in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19158,11 +19158,6 @@ snapshots:
       eslint: 9.35.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.35.0(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.35.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)


### PR DESCRIPTION
## Summary
- Back-to-back merges of #422 and #423 duplicated the `@eslint-community/eslint-utils@4.9.1(eslint@9.35.0(jiti@2.6.1))` snapshot block in `pnpm-lock.yaml`
- Duplicate YAML mapping key breaks lockfile parsing, so every CI job on main fails at `pnpm install --frozen-lockfile`
- Removes the duplicated block (only duplicate in the file; both copies were identical)

## Test Plan
- `pnpm install --frozen-lockfile` passes locally on this branch