### PR TITLE
fix: ignore agent skills dir in template prettierignore

### DIFF
--- a/kit/nextjs-anchor/.prettierignore
+++ b/kit/nextjs-anchor/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 pnpm-lock.yaml
 app/generated
 .agents
+agent

--- a/kit/nextjs/.prettierignore
+++ b/kit/nextjs/.prettierignore
@@ -2,3 +2,4 @@
 node_modules
 pnpm-lock.yaml
 .agents
+agent

--- a/kit/pinocchio-counter/.prettierignore
+++ b/kit/pinocchio-counter/.prettierignore
@@ -4,6 +4,7 @@ idl/
 # Generated files
 clients/typescript/src/generated/
 .agents/
+agent/
 skills-lock.json
 
 # Build outputs

--- a/kit/react-vite-anchor/.prettierignore
+++ b/kit/react-vite-anchor/.prettierignore
@@ -3,3 +3,4 @@ node_modules
 pnpm-lock.yaml
 src/generated
 .agents
+agent

--- a/kit/react-vite/.prettierignore
+++ b/kit/react-vite/.prettierignore
@@ -2,3 +2,4 @@ dist
 node_modules
 pnpm-lock.yaml
 .agents
+agent

--- a/mobile/kit-expo-minimal/.prettierignore
+++ b/mobile/kit-expo-minimal/.prettierignore
@@ -7,3 +7,4 @@
 /tmp
 pnpm-lock.yaml
 .agents
+agent

--- a/mobile/kit-expo-privy/.prettierignore
+++ b/mobile/kit-expo-privy/.prettierignore
@@ -8,3 +8,4 @@
 pnpm-lock.yaml
 .agents
 src/uniwind-types.d.ts
+agent

--- a/mobile/kit-expo-uniwind/.prettierignore
+++ b/mobile/kit-expo-uniwind/.prettierignore
@@ -7,3 +7,4 @@
 /tmp
 pnpm-lock.yaml
 .agents
+agent

--- a/mobile/web3js-expo-minimal/.prettierignore
+++ b/mobile/web3js-expo-minimal/.prettierignore
@@ -7,3 +7,4 @@
 /tmp
 pnpm-lock.yaml
 .agents
+agent

--- a/mobile/web3js-expo-paper/.prettierignore
+++ b/mobile/web3js-expo-paper/.prettierignore
@@ -7,3 +7,4 @@
 /tmp
 pnpm-lock.yaml
 .agents
+agent

--- a/mobile/web3js-expo/.prettierignore
+++ b/mobile/web3js-expo/.prettierignore
@@ -7,3 +7,4 @@
 /tmp
 pnpm-lock.yaml
 .agents
+agent

--- a/web3js/web3js-next-tailwind-basic/.prettierignore
+++ b/web3js/web3js-next-tailwind-basic/.prettierignore
@@ -13,3 +13,4 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 .agents
+agent

--- a/web3js/web3js-next-tailwind-basic/next.config.ts
+++ b/web3js/web3js-next-tailwind-basic/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  /* config options here */
-}
+const nextConfig: NextConfig = {/* config options here */}
 
 export default nextConfig

--- a/web3js/web3js-next-tailwind-counter/.prettierignore
+++ b/web3js/web3js-next-tailwind-counter/.prettierignore
@@ -13,3 +13,4 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 .agents
+agent

--- a/web3js/web3js-next-tailwind-counter/next.config.ts
+++ b/web3js/web3js-next-tailwind-counter/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  /* config options here */
-}
+const nextConfig: NextConfig = {/* config options here */}
 
 export default nextConfig

--- a/web3js/web3js-next-tailwind/.prettierignore
+++ b/web3js/web3js-next-tailwind/.prettierignore
@@ -7,3 +7,4 @@ package-lock.json
 pnpm-lock.yaml
 yarn.lock
 .agents
+agent

--- a/web3js/web3js-next-tailwind/next.config.ts
+++ b/web3js/web3js-next-tailwind/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {
-  /* config options here */
-}
+const nextConfig: NextConfig = {/* config options here */}
 
 export default nextConfig

--- a/web3js/web3js-react-vite-tailwind-basic/.prettierignore
+++ b/web3js/web3js-react-vite-tailwind-basic/.prettierignore
@@ -10,3 +10,4 @@
 tmp
 pnpm-lock.yaml
 .agents
+agent

--- a/web3js/web3js-react-vite-tailwind-counter/.prettierignore
+++ b/web3js/web3js-react-vite-tailwind-counter/.prettierignore
@@ -10,3 +10,4 @@
 tmp
 pnpm-lock.yaml
 .agents
+agent

--- a/web3js/web3js-react-vite-tailwind/.prettierignore
+++ b/web3js/web3js-react-vite-tailwind/.prettierignore
@@ -4,3 +4,4 @@
 tmp
 pnpm-lock.yaml
 .agents
+agent


### PR DESCRIPTION
## Summary
- `create-solana-dapp` installs the solana-dev skill via the `skills` CLI, which writes to `agent/skills/` on machines with no detected agent tooling — including CI runners
- Templates only ignored `.agents`, so `prettier --check .` (part of every template's `ci` script) failed on 28 unformatted skill markdown files in every scaffolded project
- This broke the nightly Test Templates workflow for every template since June 19 (first nightly after skills@1.5.12 shipped); PR runs never caught it because they only test changed templates
- Adds `agent` to `.prettierignore` in the 17 affected templates (the three newest templates already ship it, which is why they pass)
- Also reformats `next.config.ts` in the three `web3js-next-tailwind*` templates: scaffolds install prettier via `^3.6.2` which now resolves to 3.9, and 3.9 collapses the empty config object; this second failure was masked by the skill-markdown one

## Test Plan
- Reproduced locally: scaffolded `kit/nextjs` from main, moved skill dir to `agent/`, `prettier --check .` fails with the same 28 files; with the ignore line it passes
- Swept all 19 CI-tested templates with `prettier@latest --check` locally — only the three `next.config.ts` files were left, fixed here
- This PR touches all affected templates, so PR CI runs the full Test matrix on them — green checks here = fix verified end-to-end