### PR TITLE
fix: use empty next config object to satisfy all prettier versions

### DIFF
--- a/web3js/web3js-next-tailwind-basic/next.config.ts
+++ b/web3js/web3js-next-tailwind-basic/next.config.ts
@@ -1,5 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {/* config options here */}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/web3js/web3js-next-tailwind-counter/next.config.ts
+++ b/web3js/web3js-next-tailwind-counter/next.config.ts
@@ -1,5 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {/* config options here */}
+const nextConfig: NextConfig = {}
 
 export default nextConfig

--- a/web3js/web3js-next-tailwind/next.config.ts
+++ b/web3js/web3js-next-tailwind/next.config.ts
@@ -1,5 +1,5 @@
 import type { NextConfig } from 'next'
 
-const nextConfig: NextConfig = {/* config options here */}
+const nextConfig: NextConfig = {}
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- Follow-up to #426: main's `Validate Templates` job failed because repo-root lint pins prettier 3.6, which wants the commented empty object in `next.config.ts` expanded — while scaffolded projects resolve prettier 3.9, which collapses it. The two checks were unsatisfiable with the comment present.
- Replaces the object with a bare `{}` (no placeholder comment) in the three `web3js-next-tailwind*` templates — formats identically under both versions.
- `Validate Templates` has PR path filters that don't include template source files, so it never ran on #426 and won't run here; replicated it locally instead (see test plan).

## Test Plan
Replicated every CI job locally on this branch:
- Validate Templates steps: `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm generate`, `pnpm validate`, generated-files drift check — all green
- Checked the three files against both prettier 3.6.2 and 3.9.5 — clean on both
- Test Templates simulation for the 3 changed templates + `kit/nextjs` control: copied template, injected the solana-dev skill into `agent/` and `.agents/` exactly as the skills CLI does on CI runners, `npm install`, `npm run ci` (build + eslint + prettier) — all 4 pass
- The 16 untouched templates passed the full 53-check matrix on #426 with content identical to current main