### PR TITLE
fix(pinocchio-counter): add optional transaction logs

### DIFF
--- a/kit/pinocchio-counter/README.md
+++ b/kit/pinocchio-counter/README.md
@@ -23,6 +23,12 @@ just build          # Build program and generate clients
 just test           # Run all tests
 ```
 
+To print LiteSVM transaction logs while running integration tests, run:
+
+```bash
+TX_LOGS=1 cargo test -p tests-pinocchio-counter -- --nocapture
+```
+
 ## What's Included
 
 - **Native Solana program** using Pinocchio for minimal compute overhead

--- a/kit/pinocchio-counter/tests/integration-tests/src/utils/setup.rs
+++ b/kit/pinocchio-counter/tests/integration-tests/src/utils/setup.rs
@@ -12,6 +12,7 @@ use pinocchio_counter_client::PINOCCHIO_COUNTER_ID;
 
 const MIN_LAMPORTS: u64 = 500_000_000;
 const CU_TRACKING_ENV_VAR: &str = "CU_TRACKING";
+const TX_LOGS_ENV_VAR: &str = "TX_LOGS";
 
 pub struct TestContext {
     pub svm: LiteSVM,
@@ -82,8 +83,16 @@ impl TestContext {
         instruction: Instruction,
         signers: &[&Keypair],
     ) -> Result<u64, Box<dyn std::error::Error>> {
-        self.send_transaction_inner(instruction, signers)
-            .map_err(|e| format!("Transaction failed: {:?}", e).into())
+        match self.send_transaction_inner(instruction, signers) {
+            Ok((compute_units, logs)) => {
+                print_transaction_logs("TX OK", &logs);
+                Ok(compute_units)
+            }
+            Err((err, logs)) => {
+                print_transaction_logs("TX ERR", &logs);
+                Err(format!("Transaction failed: {:?}", err).into())
+            }
+        }
     }
 
     pub fn send_transaction_expect_error(
@@ -91,15 +100,23 @@ impl TestContext {
         instruction: Instruction,
         signers: &[&Keypair],
     ) -> TransactionError {
-        self.send_transaction_inner(instruction, signers)
-            .expect_err("Transaction should fail")
+        match self.send_transaction_inner(instruction, signers) {
+            Ok((_, logs)) => {
+                print_transaction_logs("TX OK - unexpected", &logs);
+                panic!("Transaction should fail");
+            }
+            Err((err, logs)) => {
+                print_transaction_logs("TX ERR", &logs);
+                err
+            }
+        }
     }
 
     fn send_transaction_inner(
         &mut self,
         instruction: Instruction,
         signers: &[&Keypair],
-    ) -> Result<u64, TransactionError> {
+    ) -> Result<(u64, Vec<String>), (TransactionError, Vec<String>)> {
         let mut all_signers = vec![&self.payer as &dyn Signer];
         all_signers.extend(signers.iter().map(|k| *k as &dyn Signer));
 
@@ -112,8 +129,8 @@ impl TestContext {
 
         self.svm
             .send_transaction(transaction)
-            .map(|meta| meta.compute_units_consumed)
-            .map_err(|e| e.err)
+            .map(|meta| (meta.compute_units_consumed, meta.logs))
+            .map_err(|e| (e.err, e.meta.logs))
     }
 
     pub fn get_account(&self, address: &Address) -> Option<Account> {
@@ -154,5 +171,11 @@ impl TestContext {
 impl Default for TestContext {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn print_transaction_logs(label: &str, logs: &[String]) {
+    if std::env::var(TX_LOGS_ENV_VAR).is_ok_and(|value| value == "1") {
+        println!("[{}] logs:\n{}", label, logs.join("\n"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #305.

Add optional LiteSVM transaction logging to the Pinocchio Counter template so developers can inspect program logs while debugging integration tests.

Set `TX_LOGS=1` to print logs for both successful and failed transactions. Normal test output remains unchanged when the variable is not set.

## Changes

- Preserve transaction logs returned by LiteSVM.
- Print successful and failed transaction logs when `TX_LOGS` is enabled.
- Document the environment variable in the template README.

## Usage

```bash
TX_LOGS=1 cargo test -p tests-pinocchio-counter -- --nocapture
```
