### PR TITLE
chore: update CODEOWNERS to foundation members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @catmcgee @cxalem
-/mobile @beeman
+* @solana-foundation/foundation-members


### PR DESCRIPTION
## Summary

- assign all repository paths to `@solana-foundation/foundation-members`
- remove the individual default owners and the separate mobile override

## Why

CODEOWNERS review requests should be routed through the Solana Foundation team rather than individual maintainers.

## Validation

- confirmed the `foundation-members` team slug through the GitHub API
- `git diff --check`
