### PR TITLE
Fix five community template builds

### DIFF
--- a/community/commerce-kit-store/eslint.config.mjs
+++ b/community/commerce-kit-store/eslint.config.mjs
@@ -1,14 +1,11 @@
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
+import { defineConfig, globalIgnores } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+import nextTs from 'eslint-config-next/typescript'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
-
-const eslintConfig = [...compat.extends('next/core-web-vitals', 'next/typescript')]
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
+])
 
 export default eslintConfig

--- a/community/commerce-kit-store/package.json
+++ b/community/commerce-kit-store/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "next lint",
+    "lint": "eslint",
     "start": "next start"
   },
   "displayName": "Solana Commerce Kit Store",
@@ -36,6 +36,7 @@
     "@solana/client": "^1.2.0",
     "@solana/kit": "^5.1.0",
     "@solana/react-hooks": "^1.1.5",
+    "@tanstack/react-query": "^5.90.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.24.12",
@@ -51,7 +52,6 @@
     "tw-animate-css": "^1.3.8"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "^3.3.1",
     "@tailwindcss/postcss": "^4.1.13",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.13",

--- a/community/commerce-kit-store/src/components/app-explorer-link.tsx
+++ b/community/commerce-kit-store/src/components/app-explorer-link.tsx
@@ -1,4 +1,3 @@
-import { ClusterMoniker } from '@solana/client'
 import { ArrowUpRightFromSquare } from 'lucide-react'
 
 type PathType = 'address' | 'tx' | 'block'
@@ -7,11 +6,10 @@ interface ExplorerLinkProps {
   path: string
   type: PathType
   label: string
-  cluster?: ClusterMoniker
   className?: string
 }
 
-function getExplorerUrl(path: string, type: PathType, _cluster: ClusterMoniker): string {
+function getExplorerUrl(path: string, type: PathType): string {
   const baseUrl = 'https://itx-indexer.com'
 
   if (type === 'tx') {
@@ -21,13 +19,8 @@ function getExplorerUrl(path: string, type: PathType, _cluster: ClusterMoniker):
   return `${baseUrl}/${type}/${path}`
 }
 
-function getCluster(): ClusterMoniker {
-  return (process.env.NEXT_PUBLIC_SOLANA_CLUSTER || 'devnet') as ClusterMoniker
-}
-
-export function AppExplorerLink({ path, type, label, cluster, className }: ExplorerLinkProps) {
-  const activeCluster = cluster || getCluster()
-  const url = getExplorerUrl(path, type, activeCluster)
+export function AppExplorerLink({ path, type, label, className }: ExplorerLinkProps) {
+  const url = getExplorerUrl(path, type)
 
   return (
     <a href={url} target="_blank" rel="noopener noreferrer" className={className || 'link font-mono inline-flex gap-1'}>

--- a/community/commerce-kit-store/src/components/hero-text.tsx
+++ b/community/commerce-kit-store/src/components/hero-text.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import localFont from 'next/font/local'
+import Image from 'next/image'
 import TextGlitch from '@/components/text-glitch'
 
 const font2 = localFont({
@@ -37,7 +38,7 @@ export default function HeroText() {
           <span className={`flex w-full text-[10vw] whitespace-nowrap font-black ${font3.className}`}>
             quality web3{' '}
             <span className="flex ml-[1.5vw] md:ml-[1vw]">
-              <img src="/b.svg" className="w-[8vw] h-[10vw] -mr-1 md:-mr-[2vw]" />
+              <Image src="/b.svg" alt="b" width={80} height={100} className="w-[8vw] h-[10vw] -mr-1 md:-mr-[2vw]" />
               <span className="mr-2">uilders</span>
             </span>
           </span>

--- a/community/commerce-kit-store/src/store/hooks/use-cart.ts
+++ b/community/commerce-kit-store/src/store/hooks/use-cart.ts
@@ -1,31 +1,79 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useCallback, useSyncExternalStore } from 'react'
 import type { CartItem, Cart } from '@/store/types/cart'
 import type { Product } from '@/store/types'
 
 const CART_STORAGE_KEY = 'solana-pay-store-cart'
+const CART_UPDATED_EVENT = 'solana-pay-store-cart-updated'
+const EMPTY_CART: CartItem[] = []
+let cachedCartValue: string | null = null
+let cachedCartItems: CartItem[] = EMPTY_CART
+let cartInitialized = false
 
 function getStoredCart(): CartItem[] {
-  if (typeof window === 'undefined') return []
+  if (typeof window === 'undefined') return EMPTY_CART
+  if (cartInitialized) return cachedCartItems
 
   try {
     const stored = localStorage.getItem(CART_STORAGE_KEY)
-    return stored ? JSON.parse(stored) : []
+    cachedCartValue = stored
+    cachedCartItems = stored ? JSON.parse(stored) : EMPTY_CART
   } catch (error) {
     console.error('Failed to load cart from localStorage:', error)
-    return []
+    cachedCartValue = null
+    cachedCartItems = EMPTY_CART
   }
+
+  cartInitialized = true
+  return cachedCartItems
 }
 
 function saveCart(items: CartItem[]): void {
   if (typeof window === 'undefined') return
 
+  cachedCartItems = items
+  cartInitialized = true
+
   try {
-    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items))
+    const serialized = JSON.stringify(items)
+    cachedCartValue = serialized
+    localStorage.setItem(CART_STORAGE_KEY, serialized)
   } catch (error) {
     console.error('Failed to save cart to localStorage:', error)
   }
+
+  window.dispatchEvent(new Event(CART_UPDATED_EVENT))
+}
+
+function subscribeToCart(onStoreChange: () => void): () => void {
+  const handleStorageChange = (event: StorageEvent) => {
+    if (event.key !== CART_STORAGE_KEY || event.newValue === cachedCartValue) return
+
+    try {
+      cachedCartValue = event.newValue
+      cachedCartItems = event.newValue ? JSON.parse(event.newValue) : EMPTY_CART
+    } catch (error) {
+      console.error('Failed to load cart from localStorage:', error)
+      cachedCartValue = null
+      cachedCartItems = EMPTY_CART
+    }
+
+    cartInitialized = true
+    onStoreChange()
+  }
+
+  window.addEventListener('storage', handleStorageChange)
+  window.addEventListener(CART_UPDATED_EVENT, onStoreChange)
+
+  return () => {
+    window.removeEventListener('storage', handleStorageChange)
+    window.removeEventListener(CART_UPDATED_EVENT, onStoreChange)
+  }
+}
+
+function subscribeToHydration(): () => void {
+  return () => undefined
 }
 
 function calculateCart(items: CartItem[]): Cart {
@@ -36,67 +84,72 @@ function calculateCart(items: CartItem[]): Cart {
 }
 
 export function useCart() {
-  const [items, setItems] = useState<CartItem[]>([])
-  const [isInitialized, setIsInitialized] = useState(false)
-
-  useEffect(() => {
-    setItems(getStoredCart())
-    setIsInitialized(true)
+  const items = useSyncExternalStore(subscribeToCart, getStoredCart, () => EMPTY_CART)
+  const isInitialized = useSyncExternalStore(
+    subscribeToHydration,
+    () => true,
+    () => false,
+  )
+  const updateCart = useCallback((update: (currentItems: CartItem[]) => CartItem[]) => {
+    saveCart(update(getStoredCart()))
   }, [])
 
-  useEffect(() => {
-    if (isInitialized) {
-      saveCart(items)
-    }
-  }, [items, isInitialized])
+  const addToCart = useCallback(
+    (product: Product, size: string, color: string, quantity: number = 1): boolean => {
+      const variation = product.variations.find((v) => v.size === size && v.color === color)
 
-  const addToCart = useCallback((product: Product, size: string, color: string, quantity: number = 1): boolean => {
-    const variation = product.variations.find((v) => v.size === size && v.color === color)
-
-    if (!variation || variation.stock < quantity) {
-      return false
-    }
-
-    const variationId = variation.variationId
-    const price = product.basePrice + (variation.priceModifier || 0)
-
-    setItems((currentItems) => {
-      const existingItemIndex = currentItems.findIndex((item) => item.variationId === variationId)
-
-      if (existingItemIndex >= 0) {
-        const newItems = [...currentItems]
-        const existingItem = newItems[existingItemIndex]
-        const newQuantity = existingItem.quantity + quantity
-
-        if (newQuantity > variation.stock) {
-          return currentItems
-        }
-
-        newItems[existingItemIndex] = {
-          ...existingItem,
-          quantity: newQuantity,
-        }
-        return newItems
+      if (!variation || variation.stock < quantity) {
+        return false
       }
 
-      const newItem: CartItem = {
-        product,
-        variationId,
-        size,
-        color,
-        quantity,
-        price,
-      }
+      const variationId = variation.variationId
+      const price = product.basePrice + (variation.priceModifier || 0)
 
-      return [...currentItems, newItem]
-    })
+      let didUpdate = false
+      updateCart((currentItems) => {
+        const existingItemIndex = currentItems.findIndex((item) => item.variationId === variationId)
 
-    return true
-  }, [])
+        if (existingItemIndex >= 0) {
+          const newItems = [...currentItems]
+          const existingItem = newItems[existingItemIndex]
+          const newQuantity = existingItem.quantity + quantity
 
-  const removeFromCart = useCallback((variationId: string) => {
-    setItems((currentItems) => currentItems.filter((item) => item.variationId !== variationId))
-  }, [])
+          if (newQuantity > variation.stock) {
+            return currentItems
+          }
+
+          didUpdate = true
+          newItems[existingItemIndex] = {
+            ...existingItem,
+            quantity: newQuantity,
+          }
+          return newItems
+        }
+
+        const newItem: CartItem = {
+          product,
+          variationId,
+          size,
+          color,
+          quantity,
+          price,
+        }
+
+        didUpdate = true
+        return [...currentItems, newItem]
+      })
+
+      return didUpdate
+    },
+    [updateCart],
+  )
+
+  const removeFromCart = useCallback(
+    (variationId: string) => {
+      updateCart((currentItems) => currentItems.filter((item) => item.variationId !== variationId))
+    },
+    [updateCart],
+  )
 
   const updateQuantity = useCallback(
     (variationId: string, quantity: number) => {
@@ -105,7 +158,7 @@ export function useCart() {
         return
       }
 
-      setItems((currentItems) => {
+      updateCart((currentItems) => {
         return currentItems.map((item) => {
           if (item.variationId === variationId) {
             const variation = item.product.variations.find((v) => v.variationId === variationId)
@@ -120,11 +173,11 @@ export function useCart() {
         })
       })
     },
-    [removeFromCart],
+    [removeFromCart, updateCart],
   )
 
   const clearCart = useCallback(() => {
-    setItems([])
+    saveCart(EMPTY_CART)
   }, [])
 
   const cart = calculateCart(items)

--- a/community/commerce-kit-store/src/store/hooks/use-product-variations.ts
+++ b/community/commerce-kit-store/src/store/hooks/use-product-variations.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import type { Product, SelectedVariation } from '@/store/types'
 
 interface UseProductVariationsReturn {
@@ -21,19 +21,27 @@ interface UseProductVariationsReturn {
  * Handles the business logic for product configuration
  */
 export function useProductVariations(product: Product | null): UseProductVariationsReturn {
-  const [selectedVariation, setSelectedVariation] = useState<SelectedVariation>({
-    size: null,
-    color: null,
+  const defaultVariation = useMemo<SelectedVariation>(
+    () => ({ size: null, color: product?.variations[0]?.color || null }),
+    [product],
+  )
+  const [selection, setSelection] = useState<{ productId: string | null; variation: SelectedVariation }>({
+    productId: null,
+    variation: defaultVariation,
   })
+  const productId = product?.id ?? null
+  const selectedVariation = selection.productId === productId ? selection.variation : defaultVariation
 
-  useEffect(() => {
-    if (product) {
-      setSelectedVariation({
-        size: null,
-        color: product.variations[0]?.color || null,
-      })
-    }
-  }, [product])
+  const updateSelectedVariation = (update: (current: SelectedVariation) => SelectedVariation) => {
+    setSelection((current) => ({
+      productId,
+      variation: update(current.productId === productId ? current.variation : defaultVariation),
+    }))
+  }
+
+  const setSelectedVariation = (variation: SelectedVariation) => {
+    setSelection({ productId, variation })
+  }
 
   const availableSizes = useMemo(() => {
     if (!product) return []
@@ -64,11 +72,11 @@ export function useProductVariations(product: Product | null): UseProductVariati
   const canAddToCart = useMemo(() => isSelectionComplete && stockAvailable > 0, [isSelectionComplete, stockAvailable])
 
   const setSelectedSize = (size: string) => {
-    setSelectedVariation((prev) => ({ ...prev, size }))
+    updateSelectedVariation((current) => ({ ...current, size }))
   }
 
   const setSelectedColor = (color: string) => {
-    setSelectedVariation((prev) => ({ ...prev, color }))
+    updateSelectedVariation((current) => ({ ...current, color }))
   }
 
   return {

--- a/community/drift-hello-world/package.json
+++ b/community/drift-hello-world/package.json
@@ -24,7 +24,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "next build --webpack",
     "ci": "npm run build && npm run lint && npm run format:check",
     "dev": "next dev --webpack",
     "format": "prettier --write .",

--- a/community/drift-hello-world/src/hooks/use-drift.ts
+++ b/community/drift-hello-world/src/hooks/use-drift.ts
@@ -83,7 +83,7 @@ export function useDrift() {
         setDriftClient(client);
 
         try {
-          setUserAccount(client.getUserAccount());
+          setUserAccount(client.getUserAccount() ?? null);
         } catch {
           setUserAccount(null);
         }
@@ -103,7 +103,7 @@ export function useDrift() {
   const refreshUserAccount = useCallback(() => {
     if (!driftClient) return;
     try {
-      setUserAccount(driftClient.getUserAccount());
+      setUserAccount(driftClient.getUserAccount() ?? null);
     } catch {
       setUserAccount(null);
     }
@@ -123,7 +123,8 @@ export function useDrift() {
     try {
       // Drift derives a user PDA from seeds ["user", authority, subAccountId].
       // initializeUserAccount handles the PDA derivation and account creation on-chain.
-      const signature = await driftClient.initializeUserAccount(SUB_ACCOUNT_ID);
+      const [signature] =
+        await driftClient.initializeUserAccount(SUB_ACCOUNT_ID);
       const { blockhash, lastValidBlockHeight } =
         await connection.getLatestBlockhash();
       setTxState({ action: "init", status: "pending", signature });

--- a/community/solana-chatgpt-kit/README.md
+++ b/community/solana-chatgpt-kit/README.md
@@ -74,6 +74,8 @@ cd solana-chatgpt-kit
 pnpm install
 ```
 
+> **Dependency compatibility:** `@modelcontextprotocol/sdk@1.26.0`, `mcp-handler@1.1.0`, and `zod@3.25.76` are intentionally pinned as a tested set. The MCP SDK 1.29 and Zod 3.24 combination caused TypeScript build incompatibilities. Upgrade these packages together and verify the production build before changing the pins.
+
 ### Environment Setup
 
 Create a `.env.local` file:

--- a/community/solana-chatgpt-kit/package.json
+++ b/community/solana-chatgpt-kit/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@bonfida/spl-name-service": "^3.0.16",
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "1.26.0",
     "@onsol/tldparser": "^1.0.8",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
@@ -43,13 +43,13 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.546.0",
-    "mcp-handler": "^1.1.0",
+    "mcp-handler": "1.1.0",
     "next": "16.2.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.3.1",
     "x402-solana": "^0.1.1",
-    "zod": "3.24.2"
+    "zod": "3.25.76"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/community/solana-chatgpt-kit/tsconfig.json
+++ b/community/solana-chatgpt-kit/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/community/supabase-auth/src/components/app-explorer-link.tsx
+++ b/community/supabase-auth/src/components/app-explorer-link.tsx
@@ -4,12 +4,15 @@ import { ArrowUpRightFromSquare } from 'lucide-react'
 import { useClusterState } from '@solana/react-hooks'
 import { resolveCluster } from '@/components/solana/clusters'
 
-type ExplorerLinkProps = {
+type ExplorerTarget = {
   address?: string
   block?: string
+  transaction?: string
+}
+
+type ExplorerLinkProps = ExplorerTarget & {
   className?: string
   label: string
-  transaction?: string
 }
 
 function buildExplorerUrl({
@@ -17,7 +20,7 @@ function buildExplorerUrl({
   address,
   transaction,
   block,
-}: ExplorerLinkProps & {
+}: ExplorerTarget & {
   cluster: { id: string; endpoint: string }
 }) {
   const base = 'https://explorer.solana.com'

--- a/community/supabase-auth/src/features/account/data-access/use-get-signatures-query.ts
+++ b/community/supabase-auth/src/features/account/data-access/use-get-signatures-query.ts
@@ -5,18 +5,18 @@ import { toAddress } from '@solana/client'
 import { useSolanaClient, useClusterState } from '@solana/react-hooks'
 
 type SignatureResult = {
-  blockTime: number | null
-  confirmationStatus?: string
+  blockTime: bigint | null
+  confirmationStatus: string | null
   err: unknown
-  memo?: string | null
+  memo: string | null
   signature: string
-  slot: number
+  slot: bigint
 }
 
 export function useGetSignaturesQuery({ address }: { address: string }) {
   const client = useSolanaClient()
   const cluster = useClusterState()
-  const [data, setData] = useState<SignatureResult[] | undefined>()
+  const [data, setData] = useState<readonly SignatureResult[] | undefined>()
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<unknown>()
 

--- a/community/supabase-auth/src/features/account/data-access/use-get-token-accounts-query.ts
+++ b/community/supabase-auth/src/features/account/data-access/use-get-token-accounts-query.ts
@@ -6,11 +6,12 @@ import { getTokenAccountsByOwner } from './get-token-accounts-by-owner'
 
 const TOKEN_PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'
 const TOKEN_2022_PROGRAM_ID = 'TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb'
+type TokenAccounts = Awaited<ReturnType<typeof getTokenAccountsByOwner>>
 
 export function useGetTokenAccountsQuery({ address }: { address: string }) {
   const client = useSolanaClient()
   const cluster = useClusterState()
-  const [data, setData] = useState<any[] | undefined>()
+  const [data, setData] = useState<TokenAccounts | undefined>()
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<unknown>()
 

--- a/community/supabase-auth/src/features/account/ui/account-ui-balance-check.tsx
+++ b/community/supabase-auth/src/features/account/ui/account-ui-balance-check.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { toAddress } from '@solana/client'
+import { lamports } from '@solana/kit'
 import { useBalance, useClusterState, useSolanaClient } from '@solana/react-hooks'
 import { AppAlert } from '@/components/app-alert'
 import { Button } from '@/components/ui/button'
@@ -27,7 +28,7 @@ export function AccountUiBalanceCheck({ address }: { address: string }) {
             onClick={async () => {
               setIsPending(true)
               await client.actions
-                .requestAirdrop(toAddress(address), BigInt(1_000_000_000))
+                .requestAirdrop(toAddress(address), lamports(1_000_000_000n))
                 .catch((err) => console.log(err))
                 .finally(() => setIsPending(false))
             }}

--- a/community/supabase-auth/src/features/account/ui/account-ui-balance-sol.tsx
+++ b/community/supabase-auth/src/features/account/ui/account-ui-balance-sol.tsx
@@ -1,6 +1,7 @@
 import { lamportsToSolString } from '@solana/client'
+import type { Lamports } from '@solana/kit'
 
-export function AccountUiBalanceSol({ balance }: { balance: bigint | null }) {
+export function AccountUiBalanceSol({ balance }: { balance: Lamports | null }) {
   if (balance == null) {
     return <span>0</span>
   }

--- a/community/zk-compression-airdrop/.gitignore
+++ b/community/zk-compression-airdrop/.gitignore
@@ -56,3 +56,5 @@ dev-wallet.json
 scripts/test-wallets.json
 scripts/compressed-mint-config.json
 scripts/airdrop-recipients.json
+scripts/airdrop-setup.json
+scripts/*.tmp

--- a/community/zk-compression-airdrop/scripts/create-compressed-mint.ts
+++ b/community/zk-compression-airdrop/scripts/create-compressed-mint.ts
@@ -5,6 +5,7 @@ import { createMint } from '@lightprotocol/compressed-token'
 import bs58 from 'bs58'
 import fs from 'fs'
 import path from 'path'
+import { writeJsonAtomically } from './write-json-atomically'
 
 async function main() {
   const RPC_ENDPOINT = process.env.RPC_ENDPOINT
@@ -62,7 +63,7 @@ async function main() {
     createdAt: new Date().toISOString(),
   }
 
-  fs.writeFileSync(path.join(__dirname, 'compressed-mint-config.json'), JSON.stringify(config, null, 2))
+  writeJsonAtomically(path.join(__dirname, 'compressed-mint-config.json'), config)
 
   console.log('\nConfig saved to scripts/compressed-mint-config.json')
 }

--- a/community/zk-compression-airdrop/scripts/generate-recipients.ts
+++ b/community/zk-compression-airdrop/scripts/generate-recipients.ts
@@ -1,6 +1,7 @@
 import { address, type Address } from '@solana/kit'
 import fs from 'fs'
 import path from 'path'
+import { writeJsonAtomically } from './write-json-atomically'
 
 interface Recipient {
   address: Address
@@ -53,11 +54,13 @@ async function main() {
     generatedAt: new Date().toISOString(),
   }
 
-  fs.writeFileSync(path.join(__dirname, 'airdrop-recipients.json'), JSON.stringify(airdropData, null, 2))
+  writeJsonAtomically(path.join(__dirname, 'airdrop-recipients.json'), airdropData)
+  writeJsonAtomically(path.join(__dirname, 'airdrop-setup.json'), { config, airdropData })
 
   console.log('\nRecipients list generated!')
   console.log('Total amount:', (Number(totalAmount) / 10 ** config.decimals).toLocaleString())
   console.log('Saved to scripts/airdrop-recipients.json')
+  console.log('Setup snapshot saved to scripts/airdrop-setup.json')
 }
 
 main().catch(console.error)

--- a/community/zk-compression-airdrop/scripts/write-json-atomically.ts
+++ b/community/zk-compression-airdrop/scripts/write-json-atomically.ts
@@ -1,0 +1,19 @@
+import fs from 'fs'
+
+export function writeJsonAtomically(filePath: string, value: unknown) {
+  const temporaryPath = `${filePath}.${process.pid}.tmp`
+  const serializedValue = JSON.stringify(value, null, 2)
+
+  if (serializedValue === undefined) {
+    throw new TypeError('Value cannot be serialized as JSON')
+  }
+
+  try {
+    fs.writeFileSync(temporaryPath, serializedValue)
+    fs.renameSync(temporaryPath, filePath)
+  } finally {
+    if (fs.existsSync(temporaryPath)) {
+      fs.unlinkSync(temporaryPath)
+    }
+  }
+}

--- a/community/zk-compression-airdrop/src/app/page.tsx
+++ b/community/zk-compression-airdrop/src/app/page.tsx
@@ -19,6 +19,8 @@ function loadAirdropSetup(): { config: AirdropConfig; airdropData: AirdropData }
   }
 }
 
+export const dynamic = 'force-dynamic'
+
 export default function Home() {
   const setup = loadAirdropSetup()
 

--- a/community/zk-compression-airdrop/src/app/page.tsx
+++ b/community/zk-compression-airdrop/src/app/page.tsx
@@ -6,16 +6,26 @@ import path from 'path'
 
 function loadAirdropSetup(): { config: AirdropConfig; airdropData: AirdropData } | null {
   const scriptsDirectory = path.join(process.cwd(), 'scripts')
-  const configPath = path.join(scriptsDirectory, 'compressed-mint-config.json')
-  const recipientsPath = path.join(scriptsDirectory, 'airdrop-recipients.json')
+  const setupPath = path.join(scriptsDirectory, 'airdrop-setup.json')
 
-  if (!existsSync(configPath) || !existsSync(recipientsPath)) {
+  if (!existsSync(setupPath)) {
     return null
   }
 
-  return {
-    config: JSON.parse(readFileSync(configPath, 'utf-8')) as AirdropConfig,
-    airdropData: JSON.parse(readFileSync(recipientsPath, 'utf-8')) as AirdropData,
+  try {
+    const setup = JSON.parse(readFileSync(setupPath, 'utf-8')) as {
+      config: AirdropConfig
+      airdropData: AirdropData
+    }
+
+    if (setup.config.mintAddress !== setup.airdropData.mint || setup.config.decimals !== setup.airdropData.decimals) {
+      return null
+    }
+
+    return setup
+  } catch (error) {
+    console.error('Failed to load generated airdrop setup:', error)
+    return null
   }
 }
 

--- a/community/zk-compression-airdrop/src/app/page.tsx
+++ b/community/zk-compression-airdrop/src/app/page.tsx
@@ -1,20 +1,51 @@
 import { AirdropFeature } from '@/features/airdrop'
 import { WalletInfo } from '@/components/wallet-info'
-import config from '@scripts/compressed-mint-config.json'
-import airdropData from '@scripts/airdrop-recipients.json'
+import type { AirdropConfig, AirdropData } from '@/features/airdrop/data-access/airdrop-types'
+import { existsSync, readFileSync } from 'fs'
+import path from 'path'
+
+function loadAirdropSetup(): { config: AirdropConfig; airdropData: AirdropData } | null {
+  const scriptsDirectory = path.join(process.cwd(), 'scripts')
+  const configPath = path.join(scriptsDirectory, 'compressed-mint-config.json')
+  const recipientsPath = path.join(scriptsDirectory, 'airdrop-recipients.json')
+
+  if (!existsSync(configPath) || !existsSync(recipientsPath)) {
+    return null
+  }
+
+  return {
+    config: JSON.parse(readFileSync(configPath, 'utf-8')) as AirdropConfig,
+    airdropData: JSON.parse(readFileSync(recipientsPath, 'utf-8')) as AirdropData,
+  }
+}
 
 export default function Home() {
+  const setup = loadAirdropSetup()
+
   return (
     <main className="container mx-auto py-8 max-w-4xl">
       <div className="mb-8 flex items-start justify-between">
         <div>
           <h1 className="text-4xl font-bold mb-2">ZK Compressed Token Airdrop</h1>
-          <p className="text-muted-foreground">Distribute {config.symbol} tokens to recipients using ZK compression</p>
+          <p className="text-muted-foreground">
+            {setup
+              ? `Distribute ${setup.config.symbol} tokens to recipients using ZK compression`
+              : 'Configure a compressed mint and recipient list to begin.'}
+          </p>
         </div>
         <WalletInfo />
       </div>
 
-      <AirdropFeature config={config} airdropData={airdropData} />
+      {setup ? (
+        <AirdropFeature config={setup.config} airdropData={setup.airdropData} />
+      ) : (
+        <section className="rounded-lg border p-6">
+          <h2 className="text-xl font-semibold">Setup required</h2>
+          <p className="mt-2 text-muted-foreground">
+            Run <code className="font-mono">npm run airdrop:setup</code>, then restart the app.
+          </p>
+        </section>
+      )}
     </main>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41532,6 +41532,10 @@ snapshots:
     dependencies:
       zod: 3.24.2
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       '@solana/react-hooks':
         specifier: ^1.1.5
         version: 1.4.1(@solana/sysvars@7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3))(@types/react@19.2.9)(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(utf-8-validate@5.0.10)
+      '@tanstack/react-query':
+        specifier: ^5.90.12
+        version: 5.90.12(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -108,9 +111,6 @@ importers:
         specifier: ^1.3.8
         version: 1.4.0
     devDependencies:
-      '@eslint/eslintrc':
-        specifier: ^3.3.1
-        version: 3.3.1
       '@tailwindcss/postcss':
         specifier: ^4.1.13
         version: 4.1.18
@@ -832,8 +832,8 @@ importers:
         specifier: ^3.0.16
         version: 3.0.16(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.26.0
-        version: 1.29.0(zod@3.24.2)
+        specifier: 1.26.0
+        version: 1.26.0(zod@3.25.76)
       '@onsol/tldparser':
         specifier: ^1.0.8
         version: 1.1.0(@solana/web3.js@1.98.4(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10))(bn.js@5.2.3)(borsh@2.0.0)(buffer@6.0.3)(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -862,8 +862,8 @@ importers:
         specifier: ^0.546.0
         version: 0.546.0(react@19.1.0)
       mcp-handler:
-        specifier: ^1.1.0
-        version: 1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.24.2))(next@16.2.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        specifier: 1.1.0
+        version: 1.1.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(next@16.2.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       next:
         specifier: 16.2.6
         version: 16.2.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -880,8 +880,8 @@ importers:
         specifier: ^0.1.1
         version: 0.1.5(50d4372c54c3b388a6d004cfe98605d6)
       zod:
-        specifier: 3.24.2
-        version: 3.24.2
+        specifier: 3.25.76
+        version: 3.25.76
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4
@@ -4561,8 +4561,8 @@ packages:
     resolution: {integrity: sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==}
     engines: {node: '>= 10.*'}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+  '@modelcontextprotocol/sdk@1.26.0':
+    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -20295,7 +20295,7 @@ snapshots:
 
   '@mobily/ts-belt@3.13.1': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.24.2)':
+  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.12)
       ajv: 8.17.1
@@ -20312,8 +20312,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.1
-      zod: 3.24.2
-      zod-to-json-schema: 3.25.2(zod@3.24.2)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -36049,9 +36049,9 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.24.2))(next@16.2.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.26.0(zod@3.25.76))(next@16.2.6(@babel/core@7.28.5)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.24.2)
+      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
       chalk: 5.6.2
       commander: 11.1.0
       redis: 4.7.1


### PR DESCRIPTION
## Summary

Restore build compatibility across five community templates:

- update Commerce Kit Store for current Next.js linting, required React Query peer support, and hydration-safe cart and variation state
- align Drift Hello World with current Drift SDK return types and its webpack development path
- pin a compatible MCP dependency set and normalize the Next.js TypeScript configuration in Solana ChatGPT Kit
- use current branded Solana Kit types throughout Supabase Auth
- let ZK Compression Airdrop build before generated setup exists, then atomically publish and validate a consistent runtime setup snapshot

## Why

These templates had drifted from their current framework and SDK contracts. Depending on the template, a fresh production build failed because of removed Next.js commands, missing peer dependencies, changed SDK return types, incompatible MCP/Zod resolution, stricter Solana Kit types, or imports of setup files that are intentionally generated later.

The changes keep each template usable from a fresh checkout without weakening its runtime behavior.

## Validation

- Built all five templates in production mode
- Ran lint for Commerce Kit Store, Drift Hello World, Supabase Auth, and ZK Compression Airdrop
- Verified Solana ChatGPT Kit through its production TypeScript build
- Verified missing, malformed, mismatched, and valid ZK Compression Airdrop snapshot states, plus end-to-end recipient snapshot generation
- Ran the repository template validator
- Verified the focused lockfile update with frozen dependency resolution