### PR TITLE
fix(phantom-embedded-react-native): align .env.example with code, remove personal identifiers from app.json

### DIFF
--- a/community/phantom-embedded-react-native/.env.example
+++ b/community/phantom-embedded-react-native/.env.example
@@ -4,10 +4,11 @@
 # Your Phantom App ID (Required)
 EXPO_PUBLIC_PHANTOM_APP_ID=your-app-id-here
 
-# Redirect URL after OAuth login (Required)
-# Must be whitelisted in Phantom Portal under URL Config
-# Note: For mobile apps, this should match your app's deep link scheme
-EXPO_PUBLIC_REDIRECT_URL=phantomembeddedwallet://
+# App URL scheme (Required)
+# Used by the SDK to build the OAuth redirect URL: {scheme}://phantom-auth-callback
+# Must match the "scheme" field in app.json, and the resulting redirect URL
+# must be whitelisted in Phantom Portal under URL Config
+EXPO_PUBLIC_APP_SCHEME=phantomwallet
 
 # Solana RPC Endpoint (Optional)
 EXPO_PUBLIC_SOLANA_RPC_URL=https://api.mainnet-beta.solana.com

--- a/community/phantom-embedded-react-native/app.json
+++ b/community/phantom-embedded-react-native/app.json
@@ -14,8 +14,7 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.yawei.phantomwallet",
-      "appleTeamId": "837KBXFC63",
+      "bundleIdentifier": "com.example.phantomwallet",
       "icon": "./assets/default.png"
     },
     "android": {
@@ -24,7 +23,7 @@
         "monochromeImage": "./assets/android-notification-icon.png",
         "backgroundColor": "#AB9FF2"
       },
-      "package": "com.yawei.phantomwallet",
+      "package": "com.example.phantomwallet",
       "icon": "./assets/default.png"
     },
     "web": {


### PR DESCRIPTION
.env.example declared EXPO_PUBLIC_REDIRECT_URL, which no source file reads.
app/_layout.tsx reads EXPO_PUBLIC_APP_SCHEME and derives the redirect URL as
{scheme}://phantom-auth-callback. Replace the variable and document that it
must match the "scheme" field in app.json.

app.json shipped the template author's iOS bundleIdentifier / Android package
(com.yawei.phantomwallet) and a personal appleTeamId. Replace with a neutral
placeholder and drop the team id.

